### PR TITLE
Create cp destination dir before copying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build-client:
 build-release:
 # Build backend binaries
 	cargo build -p spyglass --release
+	mkdir -p crates/tauri/binaries/spyglss-server-$(TARGET_ARCH)
 	cp target/release/spyglass crates/tauri/binaries/spyglass-server-$(TARGET_ARCH)
 # Build client
 	cargo tauri build


### PR DESCRIPTION
I was getting the following error when building from source:

```
cp target/release/spyglass crates/tauri/binaries/spyglass-server-aarch64-apple-darwin
cp: crates/tauri/binaries/spyglass-server-aarch64-apple-darwin: No such file or directory
make: *** [build-release] Error 1
```

Creating the dir before copying solves the issue. Tested by building in a clean clone.