### PR TITLE
💄 Use primary monitor instead of current

### DIFF
--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -3,7 +3,7 @@ use tauri::{async_runtime::spawn, LogicalSize, Size, Window};
 use crate::{cmd, constants};
 
 pub fn center_window(window: &Window) {
-    if let Some(monitor) = window.current_monitor().unwrap() {
+    if let Some(monitor) = window.primary_monitor().unwrap() {
         let size = monitor.size();
         let scale = monitor.scale_factor();
 


### PR DESCRIPTION
IMO current_monitor is a bit misleading as it uses the current monitor
the app is in, not the current monitor the user interacts with.

This is not optimal in a multi-monitor setup, as you often end
up with spyglass on the monitor that is not your primary. primary_monitor
on the other hand uses, you guessed it, the primary monitor, which I
see as more logical.

The optimal solution would be to get the monitor that the user is
currently interacting with, but this is not trivial.

Also, thanks for creating this awesome project! Looking forward to see the development going forward.