### PR TITLE
Crawl queue and bootstrap perf optimizations

### DIFF
--- a/crates/client/public/components/_searchbox.scss
+++ b/crates/client/public/components/_searchbox.scss
@@ -23,6 +23,10 @@
 .result-selected {
     background: darken($blue, 25%);
     .result-description, .result-url > a {
+        color: darken($fg-color, 25%) !important;
+    }
+
+    .result-title {
         color: $fg-color !important;
     }
 }
@@ -30,15 +34,19 @@
 .result-item {
     border-top: 1px solid #444;
     padding: 1.25em;
-    height: 9em;
+    height: 10em;
     box-sizing: border-box;
 
     .result-url {
         font-size: 0.9em;
+        width: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
 
         img {
-            width: 1em;
-            height: 1em;
+            width: 1.1em;
+            height: 1.1em;
             vertical-align: middle;
             margin-right: 4px;
         }
@@ -50,10 +58,14 @@
     }
 
     h2.result-title {
-        font-weight: normal;
         font-size: 1.1em;
-        padding: 0;
+        font-weight: normal;
         margin: 0.5em 0;
+        overflow: hidden;
+        padding: 0;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        width: 100%;
     }
 
     h2.result-title-lg {
@@ -66,16 +78,18 @@
     .result-description {
         color: $comment;
         line-height: 1.5em;
-        font-size: 1em;
+        font-size: 0.9em;
         overflow: hidden;
-        height: 3em;
+        text-overflow: ellipsis;
+        height: 4.25em;
+        width: 100%;
     }
 }
 
 .lens-result-item {
     border-top: 1px solid #444;
     padding: 1.25em;
-    height: 7em;
+    height: 8em;
     box-sizing: border-box;
 
     h2.result-title {

--- a/crates/client/src/components.rs
+++ b/crates/client/src/components.rs
@@ -73,7 +73,7 @@ pub fn search_result_component(res: &ResultListData, is_selected: bool) -> Html 
     match res.result_type {
         ResultListType::DocSearch => {
             let url_link = if res.url.is_some() {
-                let domain = res.domain.clone().unwrap_or("example.com".to_string());
+                let domain = res.domain.clone().unwrap_or_else(||"example.com".to_string());
                 let url = res.url.clone().unwrap();
 
                 let path = url
@@ -87,7 +87,7 @@ pub fn search_result_component(res: &ResultListData, is_selected: bool) -> Html 
                             <img src={format!("https://icons.duckduckgo.com/ip3/{}.ico", domain.clone())} />
                             {domain.clone()}
                         </a>
-                        <span>{format!(" → {}", path.clone())}</span>
+                        <span>{format!(" → {}", path)}</span>
                     </div>
                 }
             } else {

--- a/crates/client/src/components.rs
+++ b/crates/client/src/components.rs
@@ -73,13 +73,21 @@ pub fn search_result_component(res: &ResultListData, is_selected: bool) -> Html 
     match res.result_type {
         ResultListType::DocSearch => {
             let url_link = if res.url.is_some() {
-                let url = res.url.clone();
+                let domain = res.domain.clone().unwrap_or("example.com".to_string());
+                let url = res.url.clone().unwrap();
+
+                let path = url
+                    .trim_start_matches("http://")
+                    .trim_start_matches("https://")
+                    .trim_start_matches(&domain);
+
                 html! {
                     <div class={"result-url"}>
-                        <a href={res.url.clone()} target={"_blank"}>
-                            <img src={format!("https://icons.duckduckgo.com/ip3/{}.ico", res.domain.as_ref().unwrap_or(&"example.com".to_string()))} />
-                            {url.unwrap()}
+                        <a href={url.clone()} target={"_blank"}>
+                            <img src={format!("https://icons.duckduckgo.com/ip3/{}.ico", domain.clone())} />
+                            {domain.clone()}
                         </a>
+                        <span>{format!(" → {}", path.clone())}</span>
                     </div>
                 }
             } else {
@@ -88,12 +96,9 @@ pub fn search_result_component(res: &ResultListData, is_selected: bool) -> Html 
 
             html! {
                 <div class={vec![Some("result-item".to_string()), selected]}>
-                    <div class={"result-url"}>
-                        {url_link}
-                    </div>
+                    {url_link}
                     <h2 class={"result-title"}>{res.title.clone()}</h2>
                     <div class={"result-description"}>{res.description.clone()}</div>
-                    <div class={"result-score"}>{res.score}</div>
                 </div>
             }
         }

--- a/crates/reindexer/src/main.rs
+++ b/crates/reindexer/src/main.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     let added = crawl_queue::enqueue(
                         &state.db,
                         link,
-                        &state.config.user_settings,
+                        &state.user_settings,
                         &Default::default(),
                     )
                     .await

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -191,8 +191,16 @@ impl Config {
         Ok(lenses)
     }
 
+    pub fn app_identifier() -> String {
+        if cfg!(debug_assertions) {
+            "spyglass-dev".to_string()
+        } else {
+            "spyglass".to_string()
+        }
+    }
+
     pub fn data_dir() -> PathBuf {
-        let proj_dirs = ProjectDirs::from("com", "athlabs", "spyglass").unwrap();
+        let proj_dirs = ProjectDirs::from("com", "athlabs", &Config::app_identifier()).unwrap();
         proj_dirs.data_dir().to_path_buf()
     }
 
@@ -205,7 +213,8 @@ impl Config {
     }
 
     pub fn prefs_dir() -> PathBuf {
-        let proj_dirs = ProjectDirs::from("com", "athlabs", "spyglass").unwrap();
+        let proj_dirs = ProjectDirs::from("com", "athlabs", &Config::app_identifier()).unwrap();
+        log::info!("Using {:?}", proj_dirs.preference_dir().to_path_buf());
         proj_dirs.preference_dir().to_path_buf()
     }
 

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -20,7 +20,7 @@ use super::response;
 pub async fn search(state: AppState, search_req: request::SearchParam) -> Result<SearchResults> {
     let fields = Searcher::doc_fields();
 
-    let index = state.index.lock().unwrap();
+    let index = state.index;
     let searcher = index.reader.searcher();
 
     // Create a copy of the lenses for this search
@@ -124,7 +124,7 @@ pub async fn _get_current_status(state: AppState) -> jsonrpc_core::Result<AppSta
     }
 
     // Grab details about index
-    let index = state.index.lock().unwrap();
+    let index = state.index;
     let reader = index.reader.searcher();
 
     Ok(AppStatus {

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -7,12 +7,8 @@
 /// TODO: When a lens directory is created, 2 & 3 can be done by our
 /// machines and the pre-processed files can be downloaded without crawling.
 use chrono::{Duration, Utc};
-use futures::{FutureExt, Stream, StreamExt};
 use reqwest::{Client, Error};
 use std::collections::HashSet;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
 use url::Url;
@@ -36,122 +32,68 @@ fn create_archive_url(url: &str) -> String {
     )
 }
 
-type CDXResponse = Result<String, Error>;
-pub struct CDXStream {
-    pub client: Client,
-    pub is_done: bool,
-    pub limit: usize,
-    pub params: Vec<(String, String)>,
-    pub next_page_request: Option<Pin<Box<dyn Future<Output = CDXResponse>>>>,
-}
+type CDXResumeKey = Option<String>;
+type FetchCDXResult = anyhow::Result<(HashSet<String>, CDXResumeKey)>;
 
-impl CDXStream {
-    pub fn new(client: &Client, prefix: &str, limit: usize) -> Self {
-        let last_year = Utc::now() - Duration::weeks(52);
-        let last_year = last_year.format("%Y").to_string();
+async fn fetch_cdx(
+    client: &Client,
+    prefix: &str,
+    limit: usize,
+    resume_key: Option<String>,
+) -> FetchCDXResult {
+    let last_year = Utc::now() - Duration::weeks(52);
+    let last_year = last_year.format("%Y").to_string();
 
-        // More docs on parameters here:
-        // https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server#filtering
-        let params: Vec<(String, String)> = vec![
-            // TODO: Make this configurable in the lens format?
-            ("matchType".into(), "prefix".into()),
-            // Only successful pages
-            ("filter".into(), "statuscode:200".into()),
-            // Only HTML docs
-            ("filter".into(), "mimetype:text/html".into()),
-            // Remove dupes
-            ("collapse".into(), "urlkey".into()),
-            // If there are too many URLs, let's us paginate
-            ("showResumeKey".into(), "true".into()),
-            ("limit".into(), limit.to_string()),
-            // Only care about the original URL crawled
-            ("fl".into(), "original".into()),
-            // Only look at things that have existed within the last year.
-            ("from".into(), last_year),
-            ("url".into(), prefix.into()),
-        ];
+    // More docs on parameters here:
+    // https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server#filtering
+    let mut params: Vec<(String, String)> = vec![
+        // TODO: Make this configurable in the lens format?
+        ("matchType".into(), "prefix".into()),
+        // Only successful pages
+        ("filter".into(), "statuscode:200".into()),
+        // Only HTML docs
+        ("filter".into(), "mimetype:text/html".into()),
+        // Remove dupes
+        ("collapse".into(), "urlkey".into()),
+        // If there are too many URLs, let's us paginate
+        ("showResumeKey".into(), "true".into()),
+        ("limit".into(), limit.to_string()),
+        // Only care about the original URL crawled
+        ("fl".into(), "original".into()),
+        // Only look at things that have existed within the last year.
+        ("from".into(), last_year),
+        ("url".into(), prefix.into()),
+    ];
 
-        let client_clone = client.clone();
-        CDXStream {
-            client: client.clone(),
-            limit,
-            is_done: false,
-            params: params.clone(),
-            next_page_request: Some(Box::pin(async move {
-                fetch_cdx_page(client_clone, params).await
-            })),
+    if let Some(resume) = resume_key {
+        params.push(("resumeKey".into(), resume));
+    }
+
+    let response = fetch_cdx_page(client, params).await?;
+
+    let mut urls = HashSet::new();
+    let mut resume_key = None;
+
+    for url in response.split('\n') {
+        if url.is_empty() {
+            continue;
+        }
+
+        // Text after the limit num is the resume key
+        if urls.len() >= limit {
+            resume_key = Some(url.to_string());
+        } else {
+            urls.insert(url.into());
         }
     }
+
+    Ok((urls, resume_key))
 }
 
-impl Stream for CDXStream {
-    type Item = anyhow::Result<HashSet<String>>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let inner = self.get_mut();
-
-        if inner.is_done || inner.next_page_request.is_none() {
-            return Poll::Ready(None);
-        }
-
-        if let Some(mut future) = inner.next_page_request.take() {
-            return match future.poll_unpin(cx) {
-                Poll::Ready(res) => match res {
-                    Ok(response) => {
-                        let mut urls = HashSet::new();
-                        let mut resume_key = None;
-
-                        for url in response.split('\n') {
-                            if url.is_empty() {
-                                continue;
-                            }
-
-                            // Text after the limit num is the resume key
-                            if urls.len() >= inner.limit {
-                                resume_key = Some(url.to_string());
-                            } else {
-                                urls.insert(url.into());
-                            }
-                        }
-
-                        if let Some(resume_key) = resume_key {
-                            let mut new_params: Vec<(String, String)> = inner.params
-                                .iter()
-                                .filter(|(key, _)| key == "resumeKey")
-                                .map(|(k, v)| (k.to_owned(), v.to_owned()))
-                                .collect();
-
-                            new_params.push(("resumeKey".into(), resume_key));
-
-                            let client = inner.client.clone();
-                            let params_clone = new_params.clone();
-                            let fetch =
-                                Box::pin(async move { fetch_cdx_page(client, params_clone).await });
-                            inner.params = new_params.clone();
-                            inner.next_page_request = Some(fetch);
-                        } else {
-                            inner.is_done = true;
-                        }
-
-                        Poll::Ready(Some(Ok(urls)))
-                    }
-                    Err(err) => {
-                        inner.is_done = true;
-                        Poll::Ready(Some(Err(err.into())))
-                    }
-                },
-                Poll::Pending => {
-                    inner.next_page_request = Some(future);
-                    Poll::Pending
-                }
-            };
-        }
-
-        Poll::Pending
-    }
-}
-
-async fn fetch_cdx_page(client: Client, params: Vec<(String, String)>) -> CDXResponse {
+async fn fetch_cdx_page(
+    client: &Client,
+    params: Vec<(String, String)>,
+) -> anyhow::Result<String, Error> {
     let retry_strat = ExponentialBackoff::from_millis(1000).take(3);
     // If we're hitting the CDX endpoint too fast, wait a little bit before retrying.
     Retry::spawn(retry_strat, || async {
@@ -177,7 +119,8 @@ pub async fn bootstrap(
     let url = Url::parse(url)?;
 
     let client = reqwest::Client::new();
-    let mut stream = CDXStream::new(&client, &url.to_string(), 1337);
+    let mut resume_key = None;
+    let prefix = url.as_str();
 
     let mut count: usize = 0;
     let overrides = crawl_queue::EnqueueSettings {
@@ -186,9 +129,10 @@ pub async fn bootstrap(
     };
 
     // Stream pages of URLs from the CDX server & add them to our crawl queue.
-    while let Some(result) = stream.next().await {
-        if let Ok(urls) = result {
-            // Some URLs/domains might have a crazy amount of URLs, so we limit
+    loop {
+        log::info!("fetching page from cdx");
+        if let Ok((urls, resume)) = fetch_cdx(&client, prefix, 1000, resume_key.clone()).await {
+            // Some URLs/domains might have a crazy amount of crawls, so we limit
             // how much data to bootstrap based on user settings
             if let Limit::Finite(limit) = settings.domain_crawl_limit {
                 if count > limit as usize {
@@ -197,6 +141,7 @@ pub async fn bootstrap(
             }
 
             // Add URLs to crawl queue
+            log::info!("enqueing {} urls", urls.len());
             for url in urls.iter() {
                 let archive_url = create_archive_url(url);
                 match crawl_queue::enqueue(db, &archive_url, settings, &overrides).await? {
@@ -204,18 +149,23 @@ pub async fn bootstrap(
                     None => count += 1,
                 }
             }
+
+            if resume.is_none() {
+                return Ok(count);
+            }
+
+            resume_key = resume;
+        } else {
+            return Ok(count);
         }
     }
-
-    Ok(count)
 }
 
 #[cfg(test)]
 mod test {
-    use super::{bootstrap, CDXStream};
+    use super::bootstrap;
     use entities::models::crawl_queue;
     use entities::test::setup_test_db;
-    use futures::StreamExt;
 
     use shared::config::{Limit, UserSettings};
 
@@ -226,30 +176,15 @@ mod test {
     async fn test_bootstrap() {
         let db = setup_test_db().await;
         let settings = UserSettings {
-            domain_crawl_limit: Limit::Finite(2),
+            domain_crawl_limit: Limit::Infinite,
             ..Default::default()
         };
 
         let res = bootstrap(&db, &settings, "https://roll20.net/compendium/dnd5e").await;
-        assert_eq!(res.unwrap(), 2269);
+        assert_eq!(res.unwrap(), 1934);
         let num_queue = crawl_queue::num_queued(&db, crawl_queue::CrawlStatus::Queued)
             .await
             .unwrap();
-        assert_eq!(num_queue, 2269);
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_stream() {
-        let client = reqwest::Client::new();
-        let mut stream = CDXStream::new(&client, "https://roll20.net/compendium/dnd5e", 100);
-
-        let mut all_urls = Vec::new();
-        while let Some(results) = stream.next().await {
-            let page = results.unwrap();
-            all_urls.extend(page.clone());
-        }
-
-        assert_eq!(all_urls.len(), 2275);
+        assert_eq!(num_queue, 1934);
     }
 }

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -214,7 +214,7 @@ impl Crawler {
     ) -> anyhow::Result<Option<CrawlResult>, anyhow::Error> {
         let crawl = crawl_queue::Entity::find_by_id(id).one(db).await?.unwrap();
 
-        log::info!("Fetching URL: {:?}", crawl.url);
+        log::trace!("Fetching URL: {:?}", crawl.url);
         let url = Url::parse(&crawl.url).unwrap();
 
         // Break apart domain + path of the URL
@@ -225,7 +225,7 @@ impl Crawler {
         if let Some(history) = fetch_history::find_by_url(db, &url).await? {
             let since_last_fetch = Utc::now() - history.updated_at;
             if since_last_fetch < Duration::milliseconds(FETCH_DELAY_MS) {
-                log::info!("Recently fetched, skipping");
+                log::trace!("Recently fetched, skipping");
                 return Ok(None);
             }
         }
@@ -237,7 +237,7 @@ impl Crawler {
 
         // Crawl & save the data
         let result = self.crawl(&url).await;
-        log::info!(
+        log::trace!(
             "crawl result: {:?} - {:?}\n{:?}",
             result.title,
             result.url,

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -41,7 +41,12 @@ pub struct CrawlResult {
 
 impl CrawlResult {
     pub fn is_success(&self) -> bool {
+        // Success codes
         self.status >= 200 && self.status <= 299
+    }
+
+    pub fn is_bad_request(&self) -> bool {
+        self.status >= 400 && self.status <= 499
     }
 }
 

--- a/crates/spyglass/src/importer.rs
+++ b/crates/spyglass/src/importer.rs
@@ -82,16 +82,16 @@ impl FirefoxImporter {
         .await?;
 
         let mut count = 0;
-        for (_, url) in rows.iter() {
-            crawl_queue::enqueue(
-                &state.db,
-                url,
-                &self.config.user_settings,
-                &Default::default(),
-            )
-            .await?;
-            count += 1;
-        }
+        let to_add: Vec<String> = rows.into_iter().map(|(_, x)| x).collect();
+
+        crawl_queue::enqueue_all(
+            &state.db,
+            &to_add,
+            &self.config.user_settings,
+            &Default::default(),
+        )
+        .await?;
+        count += to_add.len();
 
         log::info!("imported {} urls", count);
 

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn load_lenses(state: &AppState) {
+async fn load_lenses(state: AppState) {
     for entry in state.lenses.iter() {
         let lens = entry.value();
         // Have we added this lens to the database?
@@ -90,8 +90,7 @@ async fn load_lenses(state: &AppState) {
                 }
 
                 for prefix in lens.urls.iter() {
-                    match bootstrap::bootstrap(&state.db, &state.user_settings, prefix).await
-                    {
+                    match bootstrap::bootstrap(&state.db, &state.user_settings, prefix).await {
                         Err(e) => log::error!("{}", e),
                         Ok(cnt) => log::info!("bootstraping {} w/ {} urls", prefix, cnt),
                     }
@@ -116,7 +115,7 @@ async fn start_backend(state: &AppState) {
     crawl_queue::reset_processing(&state.db).await;
 
     // Check lenses for updates & add any bootstrapped URLs to crawler.
-    load_lenses(state).await;
+    load_lenses(state.clone()).await;
 
     // Create channels for scheduler / crawlers
     let (crawl_queue_tx, crawl_queue_rx) = mpsc::channel(

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -238,7 +238,7 @@ mod test {
     use std::collections::HashMap;
 
     fn _build_test_index(searcher: &mut Searcher) {
-        let writer = &mut searcher.writer;
+        let writer = &mut searcher.writer.lock().unwrap();
         Searcher::add_document(
             writer,
             "Of Mice and Men",

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use tantivy::collector::TopDocs;
 use tantivy::directory::MmapDirectory;
@@ -25,10 +25,11 @@ pub enum IndexPath {
     Memory,
 }
 
+#[derive(Clone)]
 pub struct Searcher {
     pub index: Index,
     pub reader: IndexReader,
-    pub writer: IndexWriter,
+    pub writer: Arc<Mutex<IndexWriter>>,
 }
 
 impl Debug for Searcher {
@@ -149,7 +150,7 @@ impl Searcher {
         Searcher {
             index,
             reader,
-            writer,
+            writer: Arc::new(Mutex::new(writer)),
         }
     }
 

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -1,17 +1,17 @@
 use std::sync::{Arc, Mutex};
 
 use dashmap::DashMap;
-use entities::sea_orm::DatabaseConnection;
-use shared::config::Config;
-
-use crate::search::{IndexPath, Searcher};
 use entities::models::create_connection;
+use entities::sea_orm::DatabaseConnection;
+use shared::config::{Config, UserSettings, Lens};
+use crate::search::{IndexPath, Searcher};
 
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
     pub app_state: Arc<DashMap<String, String>>,
-    pub config: Config,
+    pub lenses: Arc<DashMap<String, Lens>>,
+    pub user_settings: UserSettings,
     pub index: Arc<Mutex<Searcher>>,
 }
 
@@ -29,10 +29,17 @@ impl AppState {
         let app_state = DashMap::new();
         app_state.insert("paused".to_string(), "false".to_string());
 
+        // Convert into dashmap
+        let lenses = DashMap::new();
+        for (key, value) in config.lenses.into_iter() {
+            lenses.insert(key, value);
+        }
+
         AppState {
             db,
             app_state: Arc::new(app_state),
-            config,
+            user_settings: config.user_settings,
+            lenses: Arc::new(lenses),
             index: Arc::new(Mutex::new(index)),
         }
     }

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -1,10 +1,10 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use crate::search::{IndexPath, Searcher};
 use dashmap::DashMap;
 use entities::models::create_connection;
 use entities::sea_orm::DatabaseConnection;
-use shared::config::{Config, UserSettings, Lens};
-use crate::search::{IndexPath, Searcher};
+use shared::config::{Config, Lens, UserSettings};
 
 #[derive(Debug, Clone)]
 pub struct AppState {
@@ -12,7 +12,7 @@ pub struct AppState {
     pub app_state: Arc<DashMap<String, String>>,
     pub lenses: Arc<DashMap<String, Lens>>,
     pub user_settings: UserSettings,
-    pub index: Arc<Mutex<Searcher>>,
+    pub index: Searcher,
 }
 
 impl AppState {
@@ -40,7 +40,7 @@ impl AppState {
             app_state: Arc::new(app_state),
             user_settings: config.user_settings,
             lenses: Arc::new(lenses),
-            index: Arc::new(Mutex::new(index)),
+            index,
         }
     }
 }

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -32,28 +32,22 @@ pub async fn manager_task(
 ) {
     log::info!("manager started");
 
-    let prioritized_domains: Vec<String> = state
-        .clone()
-        .config
-        .lenses
-        .into_values()
-        .flat_map(|lense| lense.domains)
-        .collect();
-
-    let prioritized_prefixes: Vec<String> = state
-        .config
-        .lenses
-        .into_values()
-        .flat_map(|lens| lens.urls)
-        .collect();
-
     loop {
+        let mut prioritized_domains: Vec<String> = Vec::new();
+        let mut prioritized_prefixes: Vec<String> = Vec::new();
+
+        for entry in state.lenses.iter() {
+            let value = entry.value();
+            prioritized_domains.extend(value.domains.clone());
+            prioritized_prefixes.extend(value.urls.clone());
+        }
+
         // tokio::select allows us to listen to a shutdown message while
         // also processing queue tasks.
         let next_url = tokio::select! {
             res = crawl_queue::dequeue(
                 &state.db,
-                state.config.user_settings.clone(),
+                state.user_settings.clone(),
                 &prioritized_domains,
                 &prioritized_prefixes,
             ) => res.unwrap(),
@@ -102,7 +96,7 @@ async fn _handle_fetch(state: AppState, crawler: Crawler, task: CrawlTask) {
                 let added = crawl_queue::enqueue(
                     &state.db,
                     link,
-                    &state.config.user_settings,
+                    &state.user_settings,
                     &Default::default(),
                 )
                 .await

--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -21,6 +21,7 @@ pub fn center_window(window: &Window) {
 pub fn hide_window(window: &Window) {
     window.hide().unwrap();
     window.emit("clear_search", true).unwrap();
+    spawn(cmd::resize_window(window.clone(), constants::INPUT_HEIGHT));
 }
 
 pub async fn resize_window(window: &Window, height: f64) {


### PR DESCRIPTION
## More lens improvements
- Fix filtering on CDX request so we only accept successful crawls.
- Bootstrap lenses async so that startup time is still reasonable.
- Switch to an `enqueue_all` function to add 1000s of urls/links at once vs one-at-a-time.

## Search UI
- Cleaning up results a little bit, splitting up the domain / path to make it easier to read.
<img width="686" alt="Screen Shot 2022-05-11 at 1 55 53 PM" src="https://user-images.githubusercontent.com/146222/167946287-8ce914d5-a312-474d-9821-64e18028767f.png">

## Optimizations
- Refactoring mutexes for index & config so that writing doesn't impact reading from the index.