### PR TITLE
Add setting & functionality to only crawl urls specified by lens rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "log",
+ "regex",
  "sea-orm",
  "serde",
  "shared",

--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ file found in their directory on startup, a default one will be created.
     shortcut: "CmdOrCtrl+Shift+/",
     // Where to store your index and index metadata
     // The exact default location is dependent on your OS
-    data_directory: "/Users/<username>/Library/Application Support/com.athlabs.spyglass"
+    data_directory: "/Users/<username>/Library/Application Support/com.athlabs.spyglass",
+    // By default, Spyglass will only crawl things as specified in your lenses. If you want
+    // to follow links without regard to those rules, set this to true.
+    crawl_external_links: false,
 )
 ```
 

--- a/crates/entities/Cargo.toml
+++ b/crates/entities/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
+regex = "1"
 sea-orm = { version = "^0", features = ["macros", "sqlx-sqlite", "runtime-tokio-rustls"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 shared = { path = "../shared" }

--- a/crates/entities/src/lib.rs
+++ b/crates/entities/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod models;
+pub mod regex;
 pub mod test;
 
 pub use sea_orm;

--- a/crates/entities/src/models/mod.rs
+++ b/crates/entities/src/models/mod.rs
@@ -9,7 +9,10 @@ pub mod resource_rule;
 
 use shared::config::Config;
 
-pub async fn create_connection(config: &Config, is_test: bool) -> anyhow::Result<DatabaseConnection> {
+pub async fn create_connection(
+    config: &Config,
+    is_test: bool,
+) -> anyhow::Result<DatabaseConnection> {
     let db_uri: String = if is_test {
         "sqlite::memory:".to_string()
     } else {

--- a/crates/entities/src/regex.rs
+++ b/crates/entities/src/regex.rs
@@ -1,0 +1,90 @@
+pub fn regex_for_domain(domain: &str) -> String {
+    let mut regex = String::new();
+    for ch in domain.chars() {
+        match ch {
+            '*' => regex.push_str(".*"),
+            _ => regex.push_str(&regex::escape(&ch.to_string())),
+        }
+    }
+
+    format!("(http://|https://){}.*", regex)
+}
+
+pub fn regex_for_prefix(prefix: &str) -> String {
+    format!("{}.*", prefix)
+}
+
+/// Convert a robots.txt rule into a proper regex string
+pub fn regex_for_robots(rule: &str) -> Option<String> {
+    if rule.is_empty() {
+        return None;
+    }
+
+    let mut regex = String::new();
+    let mut has_end = false;
+    for ch in rule.chars() {
+        match ch {
+            '*' => regex.push_str(".*"),
+            '^' => {
+                regex.push('^');
+                has_end = true;
+            }
+            _ => regex.push_str(&regex::escape(&ch.to_string())),
+        }
+    }
+
+    if !has_end {
+        regex.push_str(".*");
+    }
+
+    Some(regex)
+}
+
+#[cfg(test)]
+mod test {
+    use super::{regex_for_domain, regex_for_prefix};
+    use regex::Regex;
+
+    #[test]
+    fn test_regex_for_domain() {
+        // Baseline check
+        let regex = Regex::new(&regex_for_domain("en.wikipedia.org")).unwrap();
+        assert!(regex.is_match("https://en.wikipedia.org/wiki/Rust"));
+
+        // Should match http OR https
+        let regex = Regex::new(&regex_for_domain("en.wikipedia.org")).unwrap();
+        assert!(regex.is_match("http://en.wikipedia.org/wiki/Rust"));
+
+        // Wildcard should match anything
+        let regex = Regex::new(&regex_for_domain("*.wikipedia.org")).unwrap();
+        for test in [
+            "https://en.wikipedia.org/wiki/Rust",
+            "http://sub.sub.wikipedia.org/wiki/blah",
+        ] {
+            assert!(regex.is_match(test));
+        }
+    }
+
+    #[test]
+    fn test_regex_for_prefix() {
+        let prefix = "https://roll20.net/compendium/dnd5e";
+        let regex = Regex::new(&regex_for_prefix(prefix)).unwrap();
+        // Successes
+        for test in [
+            "https://roll20.net/compendium/dnd5e",
+            "https://roll20.net/compendium/dnd5e/monsters",
+            "https://roll20.net/compendium/dnd5e.html",
+        ] {
+            assert!(regex.is_match(test));
+        }
+
+        // Failures
+        for test in [
+            "https://sub.roll20.net",
+            "https://en.wikipedia.org",
+            "https://localhost",
+        ] {
+            assert!(!regex.is_match(test));
+        }
+    }
+}

--- a/crates/reindexer/src/main.rs
+++ b/crates/reindexer/src/main.rs
@@ -4,7 +4,7 @@ use entities::sea_orm::{ActiveModelTrait, EntityTrait, PaginatorTrait, QueryOrde
 use libspyglass::crawler::Crawler;
 use libspyglass::search::Searcher;
 use libspyglass::state::AppState;
-use shared::config::Config;
+use shared::config::{Config, Lens};
 use url::Url;
 
 #[tokio::main]
@@ -73,9 +73,15 @@ async fn main() -> Result<(), anyhow::Error> {
 
                 // Update parsed links
                 let to_add: Vec<String> = scrape.links.into_iter().collect();
+                let lenses: Vec<Lens> = state
+                    .lenses
+                    .iter()
+                    .map(|entry| entry.value().clone())
+                    .collect();
                 crawl_queue::enqueue_all(
                     &state.db,
                     &to_add,
+                    &lenses,
                     &state.user_settings,
                     &Default::default(),
                 )

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -75,10 +75,15 @@ pub struct UserSettings {
     pub allow_list: Vec<String>,
     /// Domains explicitly blocked from crawling.
     pub block_list: Vec<String>,
+    /// Search bar activation hot key
     #[serde(default = "UserSettings::default_shortcut")]
+    /// Directory for metadata & index
     pub shortcut: String,
     #[serde(default = "UserSettings::default_data_dir")]
     pub data_directory: PathBuf,
+    /// Should we crawl links that don't match our lens rules?
+    #[serde(default)]
+    pub crawl_external_links: bool,
 }
 
 impl UserSettings {
@@ -124,6 +129,7 @@ impl Default for UserSettings {
             shortcut: UserSettings::default_shortcut(),
             // Where to store the metadata & index
             data_directory: UserSettings::default_data_dir(),
+            crawl_external_links: false,
         }
     }
 }
@@ -252,7 +258,10 @@ impl Config {
             Default::default()
         });
 
-        let mut config = Config { lenses: HashMap::new(), user_settings };
+        let mut config = Config {
+            lenses: HashMap::new(),
+            user_settings,
+        };
 
         let data_dir = config.data_dir();
         fs::create_dir_all(&data_dir).expect("Unable to create data folder");
@@ -277,13 +286,16 @@ impl Config {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
     use crate::config::Config;
+    use std::collections::HashMap;
 
     #[test]
     #[ignore]
     pub fn test_load_lenses() {
-        let mut config = Config { lenses: HashMap::new(), user_settings: Default::default() };
+        let mut config = Config {
+            lenses: HashMap::new(),
+            user_settings: Default::default(),
+        };
         let res = config.load_lenses();
         assert!(!res.is_err());
     }

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -125,6 +125,7 @@ pub async fn bootstrap(
     let mut count: usize = 0;
     let overrides = crawl_queue::EnqueueSettings {
         skip_blocklist: true,
+        skip_lenses: true,
         crawl_type: crawl_queue::CrawlType::Bootstrap,
     };
 
@@ -143,7 +144,7 @@ pub async fn bootstrap(
             // Add URLs to crawl queue
             log::info!("enqueing {} urls", urls.len());
             let urls: Vec<String> = urls.into_iter().collect();
-            crawl_queue::enqueue_all(db, &urls, settings, &overrides).await?;
+            crawl_queue::enqueue_all(db, &urls, &Vec::new(), settings, &overrides).await?;
             count += urls.len();
 
             if resume.is_none() {

--- a/crates/spyglass/src/importer.rs
+++ b/crates/spyglass/src/importer.rs
@@ -5,6 +5,7 @@ use std::{env, fs, path::PathBuf};
 
 use entities::models::crawl_queue;
 use libspyglass::state::AppState;
+use shared::config::Lens;
 
 #[allow(dead_code)]
 pub struct FirefoxImporter {
@@ -83,10 +84,11 @@ impl FirefoxImporter {
 
         let mut count = 0;
         let to_add: Vec<String> = rows.into_iter().map(|(_, x)| x).collect();
-
+        let lenses: Vec<Lens> = self.config.lenses.clone().into_values().collect();
         crawl_queue::enqueue_all(
             &state.db,
             &to_add,
+            &lenses,
             &self.config.user_settings,
             &Default::default(),
         )

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -6,7 +6,9 @@ use url::Url;
 use crate::crawler::Crawler;
 use crate::search::Searcher;
 use crate::state::AppState;
+
 use entities::models::{crawl_queue, indexed_document};
+use shared::config::Lens;
 
 #[derive(Debug, Clone)]
 pub struct CrawlTask {
@@ -98,9 +100,15 @@ async fn _handle_fetch(state: AppState, crawler: Crawler, task: CrawlTask) {
 
             // Add all valid, non-duplicate, non-indexed links found to crawl queue
             let to_enqueue: Vec<String> = crawl_result.links.into_iter().collect();
+            let lenses: Vec<Lens> = state
+                .lenses
+                .iter()
+                .map(|entry| entry.value().clone())
+                .collect();
             if let Err(err) = crawl_queue::enqueue_all(
                 &state.db,
                 &to_enqueue,
+                &lenses,
                 &state.user_settings,
                 &Default::default(),
             )

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -47,7 +47,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ctx = tauri::generate_context!();
 
-
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             cmd::escape,


### PR DESCRIPTION
- By default, only crawl URLs that match rules inside lenses.