### PR TITLE
Crawls for bootstrapped urls should check against the og domain

### DIFF
--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -238,7 +238,13 @@ impl Crawler {
         }
 
         // Check for robots.txt of this domain
-        if !check_resource_rules(db, &self.client, &url).await? {
+        // When looking at bootstrapped tasks, check the original URL
+        if crawl.crawl_type == crawl_queue::CrawlType::Bootstrap {
+            let og_url = Url::parse(&crawl.url).unwrap();
+            if !check_resource_rules(db, &self.client, &og_url).await? {
+                return Ok(None);
+            }
+        } else if !check_resource_rules(db, &self.client, &url).await? {
             return Ok(None);
         }
 


### PR DESCRIPTION
Fixes an issue where URLs not normally crawlable would make it through to the index (e.g. the "edit" page of a wiki page)