### PR TITLE
Add support for lens rulesets, starting with `SkipURL`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ dependencies = [
  "chrono",
  "log",
  "regex",
+ "ron",
  "sea-orm",
  "serde",
  "shared",

--- a/crates/entities/Cargo.toml
+++ b/crates/entities/Cargo.toml
@@ -15,3 +15,6 @@ serde = { version = "1.0", features = ["derive"] }
 shared = { path = "../shared" }
 tokio = { version = "1", features = ["full"] }
 url = "2.2"
+
+[dev-dependencies]
+ron = "0.7"

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -7,9 +7,9 @@ use sea_orm::{sea_query, DbBackend, FromQueryResult, QuerySelect, Set, Statement
 use serde::Serialize;
 use url::Url;
 
+use crate::regex::{regex_for_domain, regex_for_prefix, regex_for_robots, WildcardType};
 use super::indexed_document;
-use crate::regex::{regex_for_domain, regex_for_prefix};
-use shared::config::{Lens, Limit, UserSettings};
+use shared::config::{Lens, LensRule, Limit, UserSettings};
 
 const MAX_RETRIES: u8 = 5;
 
@@ -212,6 +212,39 @@ fn gen_priority_sql(p_domains: &str, p_prefixes: &str, user_settings: UserSettin
         ],
     )
 }
+struct LensRuleSets {
+    allow_list: Vec<String>,
+    skip_list: Vec<String>,
+}
+
+/// Create a set of allow/skip rules from a Lens
+fn create_ruleset_from_lens(lens: &Lens) -> LensRuleSets {
+    let mut allow_list = Vec::new();
+    let mut skip_list: Vec<String> = Vec::new();
+
+    // Build regex from domain
+    for domain in lens.domains.iter() {
+        allow_list.push(regex_for_domain(domain));
+    }
+
+    // Build regex from url rules
+    for prefix in lens.urls.iter() {
+        allow_list.push(regex_for_prefix(prefix));
+    }
+
+    // Build regex from rules
+    for rule in lens.rules.iter() {
+        match rule {
+            LensRule::SkipURL(rule_str) => skip_list
+                .push(regex_for_robots(rule_str, WildcardType::Regex).unwrap()),
+        }
+    }
+
+    LensRuleSets {
+        allow_list,
+        skip_list,
+    }
+}
 
 /// Get the next url in the crawl queue
 pub async fn dequeue(
@@ -282,16 +315,12 @@ pub async fn enqueue_all(
     overrides: &EnqueueSettings,
 ) -> anyhow::Result<(), sea_orm::DbErr> {
     let mut allow_list: Vec<String> = Vec::new();
-    for lens in lenses {
-        // Build regex from domain
-        for domain in lens.domains.iter() {
-            allow_list.push(regex_for_domain(domain));
-        }
+    let mut skip_list: Vec<String> = Vec::new();
 
-        // Build regex from url rules
-        for prefix in lens.urls.iter() {
-            allow_list.push(regex_for_prefix(prefix));
-        }
+    for lens in lenses {
+        let ruleset = create_ruleset_from_lens(lens);
+        allow_list.extend(ruleset.allow_list);
+        skip_list.extend(ruleset.skip_list);
     }
 
     let allow_list = RegexSet::new(allow_list).unwrap();
@@ -579,5 +608,25 @@ mod test {
         dbg!(&regex);
         let removed = super::remove_by_rule(&db, &regex).await.unwrap();
         assert_eq!(removed, 2);
+    }
+
+    #[tokio::test]
+    async fn test_create_ruleset() {
+        let lens =
+            ron::from_str::<Lens>(include_str!("../../../../fixtures/lens/test.ron")).unwrap();
+
+        let rules = super::create_ruleset_from_lens(&lens);
+        let allow_list = regex::RegexSet::new(rules.allow_list).unwrap();
+        let block_list = regex::RegexSet::new(rules.skip_list).unwrap();
+
+        let valid = "https://walkingdead.fandom.com/wiki/18_Miles_Out";
+        let invalid = "https://walkingdead.fandom.com/wiki/Aaron_(Comic_Series)/Gallery";
+
+        assert!(allow_list.is_match(valid));
+        assert!(!block_list.is_match(valid));
+        // Allowed without the SkipURL
+        assert!(allow_list.is_match(invalid));
+        // but should now be denied
+        assert!(block_list.is_match(invalid));
     }
 }

--- a/crates/entities/src/regex.rs
+++ b/crates/entities/src/regex.rs
@@ -33,7 +33,7 @@ pub fn regex_for_robots(rule: &str) -> Option<String> {
         }
     }
 
-    if !has_end {
+    if !has_end && !regex.ends_with(".*") {
         regex.push_str(".*");
     }
 

--- a/crates/entities/src/regex.rs
+++ b/crates/entities/src/regex.rs
@@ -43,7 +43,13 @@ pub fn regex_for_robots(rule: &str, wildcard_type: WildcardType) -> Option<Strin
                     has_end = true;
                 }
             }
-            _ => regex.push_str(&regex::escape(&ch.to_string())),
+            _ => {
+                if wildcard_type == WildcardType::Regex {
+                    regex.push_str(&regex::escape(&ch.to_string()));
+                } else {
+                    regex.push(ch);
+                }
+            }
         }
     }
 

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -20,6 +20,14 @@ impl Default for Config {
     }
 }
 
+/// Different rules that filter out the URLs that would be crawled for a lens
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum LensRule {
+    /// Robots.txt regex to skip certain URLs
+    /// Skips are applied when bootstrapping & crawling
+    SkipURL(String),
+}
+
 /// Contexts are a set of domains/URLs/etc. that restricts a search space to
 /// improve results.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -33,6 +41,8 @@ pub struct Lens {
     pub version: String,
     #[serde(default = "Lens::default_is_enabled")]
     pub is_enabled: bool,
+    #[serde(default)]
+    pub rules: Vec<LensRule>,
 }
 
 impl Lens {

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -124,8 +124,6 @@ pub async fn bootstrap(
 
     let mut count: usize = 0;
     let overrides = crawl_queue::EnqueueSettings {
-        skip_blocklist: true,
-        skip_lenses: true,
         crawl_type: crawl_queue::CrawlType::Bootstrap,
     };
 

--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -3,7 +3,7 @@
 /// - https://developers.google.com/search/docs/advanced/robots/intro
 /// - https://www.robotstxt.org/robotstxt.html
 use entities::models::resource_rule;
-use entities::regex::regex_for_robots;
+use entities::regex::{regex_for_robots, WildcardType};
 use entities::sea_orm::prelude::*;
 use entities::sea_orm::{DatabaseConnection, Set};
 
@@ -68,7 +68,7 @@ pub fn parse(domain: &str, txt: &str) -> Vec<ParsedRule> {
                     }
 
                     if prefix.starts_with("disallow") || prefix.starts_with("allow") {
-                        let regex = regex_for_robots(end.trim());
+                        let regex = regex_for_robots(end.trim(), WildcardType::Regex);
                         if let Some(regex) = regex {
                             rules.push(ParsedRule {
                                 domain: domain.to_string(),
@@ -79,7 +79,7 @@ pub fn parse(domain: &str, txt: &str) -> Vec<ParsedRule> {
                         } else if regex.is_none() && prefix.starts_with("disallow") {
                             rules.push(ParsedRule {
                                 domain: domain.to_string(),
-                                regex: regex_for_robots("/").unwrap(),
+                                regex: regex_for_robots("/", WildcardType::Regex).unwrap(),
                                 allow_crawl: true,
                             });
                         }
@@ -191,7 +191,7 @@ mod test {
     use crate::crawler::Crawler;
 
     use entities::models::resource_rule;
-    use entities::regex::regex_for_robots;
+    use entities::regex::{regex_for_robots, WildcardType};
     use entities::sea_orm::{ActiveModelTrait, Set};
     use entities::test::setup_test_db;
     use regex::Regex;
@@ -222,7 +222,7 @@ mod test {
 
     #[test]
     fn test_rule_to_regex() {
-        let regex = regex_for_robots("/*?title=Property:").unwrap();
+        let regex = regex_for_robots("/*?title=Property:", WildcardType::Regex).unwrap();
         assert_eq!(regex, "/.*\\?title=Property:.*");
 
         let re = Regex::new(&regex).unwrap();

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -32,7 +32,8 @@ fn create_ruleset_from_lens(lens: &Lens) -> LensRuleSets {
     // Build regex from rules
     for rule in lens.rules.iter() {
         match rule {
-            LensRule::SkipURL(rule_str) => skip_list.push(regex_for_robots(&rule_str).unwrap()),
+            LensRule::SkipURL(rule_str) => skip_list
+                .push(regex_for_robots(&rule_str, entities::regex::WildcardType::Regex).unwrap()),
         }
     }
 
@@ -124,7 +125,9 @@ pub async fn load_lenses(state: AppState) {
         }
     }
 
-    // Bootstrap new lenses
+    // Bootstrap lenses.
+    // Check & bootstrap will go through domains/prefixes and bootstrap a crawl queue
+    // if we have not already done so.
     for lens in new_lenses {
         for domain in lens.domains.iter() {
             let seed_url = format!("https://{}", domain);

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -12,22 +12,21 @@ async fn create_default_lens(config: &Config) {
     let lens = Lens {
         author: "Spyglass".to_string(),
         version: "1".to_string(),
-        name: "wiki".to_string(),
+        name: "rust".to_string(),
         description: Some(
-            "Search through official user-supported wikis for knowledge, games, and more."
+            "All things Rustlang. Search through Rust blogs, the rust book, and
+            more."
                 .to_string(),
         ),
-        domains: vec!["blog.rust-lang.org".into(), "wiki.factorio.com".into()],
+        domains: vec!["blog.rust-lang.org".into()],
         urls: vec![
-            "https://https://en.wikipedia.org/wiki/Portal:".into(),
             "https://doc.rust-lang.org/book/".into(),
-            "https://oldschool.runescape.wiki/w/".into(),
         ],
         is_enabled: true,
     };
 
     fs::write(
-        config.lenses_dir().join("wiki.ron"),
+        config.lenses_dir().join("rust.ron"),
         ron::ser::to_string_pretty(&lens, Default::default()).unwrap(),
     )
     .expect("Unable to save default lens file.");

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -84,8 +84,6 @@ impl Searcher {
     pub fn delete(writer: &mut IndexWriter, id: &str) -> anyhow::Result<()> {
         let fields = Searcher::doc_fields();
         writer.delete_term(Term::from_field_text(fields.id, id));
-        writer.commit()?;
-
         Ok(())
     }
 

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -248,6 +248,7 @@ pub async fn worker_task(
     }
 }
 
+/// Watches the lens folder for new/updated lenses & reloads the metadata.
 pub async fn lens_watcher(
     state: AppState,
     config: Config,

--- a/fixtures/lens/test.ron
+++ b/fixtures/lens/test.ron
@@ -1,0 +1,21 @@
+(
+    version: "1",
+    name: "twd",
+    author: "@test",
+    description: Some("test description"),
+    is_enabled: true,
+    domains: [],
+    urls: [
+        "https://walkingdead.fandom.com/wiki"
+    ],
+    rules: [
+        // Skip meta categories & user related pages
+        SkipURL("https://walkingdead.fandom.com/wiki/Category:*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/Talk:*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/Template:*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/Thread:*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/*/Gallery*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/User:*"),
+        SkipURL("https://walkingdead.fandom.com/wiki/User_blog:*")
+    ]
+)


### PR DESCRIPTION
- Add a `rules` param to lenses.
- Rules (for now) only take `SkipURLs` which are minimal regexes that when matching a URL will skip it during a crawl.

Rules are especially useful for skipping over parts of a website that aren't really relevant for a topic. For example, any MediaWiki site, such as`wiki.factorio.com`, has lots of extra MediaWiki specific pages that are technically allowed to be indexed such as User/Talk/Template pages or edit/history pages which might not be useful when searching.
