### PR TITLE
Ability to delete indexed documents from search results

### DIFF
--- a/crates/client/public/glue.js
+++ b/crates/client/public/glue.js
@@ -17,6 +17,10 @@ export async function onFocus(callback) {
     await listen('focus_window', callback);
 }
 
+export async function onRefreshResults(callback) {
+    await listen('refresh_results', callback);
+}
+
 export async function crawlStats() {
     return await invoke("crawl_stats");
 }

--- a/crates/client/public/glue.js
+++ b/crates/client/public/glue.js
@@ -21,6 +21,10 @@ export async function crawlStats() {
     return await invoke("crawl_stats");
 }
 
+export async function deleteDoc(id) {
+    return await invoke("delete_doc", { id });
+}
+
 export async function searchDocs(lenses, query) {
     return await invoke("search_docs", { lenses, query });
 }

--- a/crates/client/public/main.css
+++ b/crates/client/public/main.css
@@ -468,6 +468,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-backdrop-sepia:  ;
 }
 
+.absolute {
+  position: absolute;
+}
+
 .relative {
   position: relative;
 }
@@ -483,6 +487,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .z-40 {
   z-index: 40;
+}
+
+.float-right {
+  float: right;
 }
 
 .my-3 {
@@ -506,12 +514,76 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-left: 0.75rem;
 }
 
+.-mt-4 {
+  margin-top: -1rem;
+}
+
+.-mt-16 {
+  margin-top: -4rem;
+}
+
+.-mt-6 {
+  margin-top: -1.5rem;
+}
+
+.-mt-7 {
+  margin-top: -1.75rem;
+}
+
+.-ml-6 {
+  margin-left: -1.5rem;
+}
+
+.-ml-2 {
+  margin-left: -0.5rem;
+}
+
+.-ml-4 {
+  margin-left: -1rem;
+}
+
+.-mt-9 {
+  margin-top: -2.25rem;
+}
+
+.-ml-10 {
+  margin-left: -2.5rem;
+}
+
+.-ml-12 {
+  margin-left: -3rem;
+}
+
+.-mt-1 {
+  margin-top: -0.25rem;
+}
+
+.-ml-14 {
+  margin-left: -3.5rem;
+}
+
+.-ml-16 {
+  margin-left: -4rem;
+}
+
+.-mt-2 {
+  margin-top: -0.5rem;
+}
+
+.block {
+  display: block;
+}
+
 .inline {
   display: inline;
 }
 
 .flex {
   display: flex;
+}
+
+.hidden {
+  display: none;
 }
 
 .h-6 {
@@ -534,6 +606,34 @@ Ensure the default browser behavior of the `hidden` attribute.
   height: 6rem;
 }
 
+.h-10 {
+  height: 2.5rem;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.h-40 {
+  height: 10rem;
+}
+
+.h-36 {
+  height: 9rem;
+}
+
+.h-32 {
+  height: 8rem;
+}
+
+.h-28 {
+  height: 7rem;
+}
+
+.h-2 {
+  height: 0.5rem;
+}
+
 .w-6 {
   width: 1.5rem;
 }
@@ -554,12 +654,32 @@ Ensure the default browser behavior of the `hidden` attribute.
   width: 4rem;
 }
 
+.w-10 {
+  width: 2.5rem;
+}
+
+.w-2 {
+  width: 0.5rem;
+}
+
 .flex-1 {
   flex: 1 1 0%;
 }
 
+.flex-none {
+  flex: none;
+}
+
+.shrink {
+  flex-shrink: 1;
+}
+
 .grow {
   flex-grow: 1;
+}
+
+.grow-0 {
+  flex-grow: 0;
 }
 
 @-webkit-keyframes spin {
@@ -654,9 +774,23 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-top-width: 1px;
 }
 
+.border-l {
+  border-left-width: 1px;
+}
+
 .border-neutral-600 {
   --tw-border-opacity: 1;
   border-color: rgb(82 82 82 / var(--tw-border-opacity));
+}
+
+.border-black {
+  --tw-border-opacity: 1;
+  border-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+
+.border-l-neutral-600 {
+  --tw-border-opacity: 1;
+  border-left-color: rgb(82 82 82 / var(--tw-border-opacity));
 }
 
 .bg-neutral-800 {
@@ -714,6 +848,16 @@ Ensure the default browser behavior of the `hidden` attribute.
   background-color: rgb(28 25 23 / var(--tw-bg-opacity));
 }
 
+.bg-black {
+  --tw-bg-opacity: 1;
+  background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+}
+
+.bg-neutral-900 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(23 23 23 / var(--tw-bg-opacity));
+}
+
 .p-4 {
   padding: 1rem;
 }
@@ -732,6 +876,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .p-0 {
   padding: 0px;
+}
+
+.p-1 {
+  padding: 0.25rem;
 }
 
 .py-4 {
@@ -754,6 +902,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding-bottom: 0.5rem;
 }
 
+.px-2 {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
 .pt-4 {
   padding-top: 1rem;
 }
@@ -764,6 +917,22 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .pb-1 {
   padding-bottom: 0.25rem;
+}
+
+.pl-2 {
+  padding-left: 0.5rem;
+}
+
+.pl-4 {
+  padding-left: 1rem;
+}
+
+.pr-0 {
+  padding-right: 0px;
+}
+
+.text-center {
+  text-align: center;
 }
 
 .align-middle {
@@ -819,9 +988,29 @@ Ensure the default browser behavior of the `hidden` attribute.
   color: rgb(163 163 163 / var(--tw-text-opacity));
 }
 
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
+}
+
+.text-neutral-600 {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 82 / var(--tw-text-opacity));
+}
+
 .hover\:bg-neutral-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(82 82 82 / var(--tw-bg-opacity));
+}
+
+.hover\:text-cyan-50:hover {
+  --tw-text-opacity: 1;
+  color: rgb(236 254 255 / var(--tw-text-opacity));
+}
+
+.hover\:text-red-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity));
 }
 
 .focus\:outline-none:focus {
@@ -832,4 +1021,33 @@ Ensure the default browser behavior of the `hidden` attribute.
 .active\:bg-neutral-700:active {
   --tw-bg-opacity: 1;
   background-color: rgb(64 64 64 / var(--tw-bg-opacity));
+}
+
+.group:hover .group-hover\:block {
+  display: block;
+}
+
+.group:hover .group-hover\:text-neutral-600 {
+  --tw-text-opacity: 1;
+  color: rgb(82 82 82 / var(--tw-text-opacity));
+}
+
+.group:hover .group-hover\:text-neutral-400 {
+  --tw-text-opacity: 1;
+  color: rgb(163 163 163 / var(--tw-text-opacity));
+}
+
+.group:hover .group-hover\:text-red-400 {
+  --tw-text-opacity: 1;
+  color: rgb(248 113 113 / var(--tw-text-opacity));
+}
+
+.group:hover .group-hover\:text-red-500 {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity));
+}
+
+.group:hover .group-hover\:text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }

--- a/crates/client/public/main.css
+++ b/crates/client/public/main.css
@@ -931,6 +931,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding-right: 0px;
 }
 
+.pr-1 {
+  padding-right: 0.25rem;
+}
+
 .text-center {
   text-align: center;
 }

--- a/crates/client/src/components/btn.rs
+++ b/crates/client/src/components/btn.rs
@@ -1,0 +1,54 @@
+use yew::prelude::*;
+
+#[function_component(Tooltip)]
+pub fn tooltip() -> Html {
+    let styles = vec![
+        "group-hover:block",
+        "group-hover:text-neutral-400",
+        "py-1",
+        "px-2",
+        // Positioning
+        "-ml-16",
+        "-mt-2",
+        "rounded",
+        "hidden",
+        "absolute",
+        "text-center",
+        "bg-neutral-900",
+        "text-sm",
+    ];
+
+    html! {
+        <div class={styles}>
+            {"Delete"}
+        </div>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct DeleteButtonProps {
+    pub doc_id: String,
+}
+
+#[function_component(DeleteButton)]
+pub fn delete_btn(props: &DeleteButtonProps) -> Html {
+    let onclick = {
+        let doc_id = props.doc_id.clone();
+        move |_| {
+            log::info!("DELETING DOC {}", doc_id);
+        }
+    };
+
+    html! {
+        <div class="float-right pl-4 pr-0 h-28">
+            <button
+                {onclick}
+                class="hover:text-red-600 text-neutral-600 group">
+                <Tooltip />
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+            </button>
+        </div>
+    }
+}

--- a/crates/client/src/components/btn.rs
+++ b/crates/client/src/components/btn.rs
@@ -1,7 +1,13 @@
+use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
 
+#[derive(Properties, PartialEq)]
+pub struct TooltipProps {
+    pub label: String,
+}
+
 #[function_component(Tooltip)]
-pub fn tooltip() -> Html {
+pub fn tooltip(props: &TooltipProps) -> Html {
     let styles = vec![
         "group-hover:block",
         "group-hover:text-neutral-400",
@@ -20,7 +26,7 @@ pub fn tooltip() -> Html {
 
     html! {
         <div class={styles}>
-            {"Delete"}
+            {props.label.clone()}
         </div>
     }
 }
@@ -30,12 +36,18 @@ pub struct DeleteButtonProps {
     pub doc_id: String,
 }
 
+fn handle_delete(doc_id: String) {
+    spawn_local(async move {
+        let _ = crate::delete_doc(doc_id.clone()).await;
+    });
+}
+
 #[function_component(DeleteButton)]
 pub fn delete_btn(props: &DeleteButtonProps) -> Html {
     let onclick = {
         let doc_id = props.doc_id.clone();
         move |_| {
-            log::info!("DELETING DOC {}", doc_id);
+            handle_delete(doc_id.clone());
         }
     };
 
@@ -44,7 +56,7 @@ pub fn delete_btn(props: &DeleteButtonProps) -> Html {
             <button
                 {onclick}
                 class="hover:text-red-600 text-neutral-600 group">
-                <Tooltip />
+                <Tooltip label={"Delete"} />
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                 </svg>

--- a/crates/client/src/components/btn.rs
+++ b/crates/client/src/components/btn.rs
@@ -52,15 +52,13 @@ pub fn delete_btn(props: &DeleteButtonProps) -> Html {
     };
 
     html! {
-        <div class="float-right pl-4 pr-0 h-28">
-            <button
-                {onclick}
-                class="hover:text-red-600 text-neutral-600 group">
-                <Tooltip label={"Delete"} />
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-            </button>
-        </div>
+        <button
+            {onclick}
+            class="hover:text-red-600 text-neutral-600 group">
+            <Tooltip label={"Delete"} />
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+        </button>
     }
 }

--- a/crates/client/src/components/mod.rs
+++ b/crates/client/src/components/mod.rs
@@ -97,6 +97,7 @@ pub fn search_result_component(props: &SearchResultProps) -> Html {
         "border-t".into(),
         "border-neutral-600".into(),
         "p-4".into(),
+        "pr-0".into(),
         "text-white".into(),
         selected,
     ];
@@ -133,7 +134,9 @@ pub fn search_result_component(props: &SearchResultProps) -> Html {
 
             html! {
                 <div class={component_styles}>
-                    <DeleteButton doc_id={result.id.clone()} />
+                    <div class="float-right pl-4 mr-2 h-28">
+                        <DeleteButton doc_id={result.id.clone()} />
+                    </div>
                     {url_link}
                     <h2 class={"text-lg truncate py-1"}>
                         {result.title.clone()}

--- a/crates/client/src/components/mod.rs
+++ b/crates/client/src/components/mod.rs
@@ -1,6 +1,9 @@
 use shared::response::{LensResult, SearchResult};
 use yew::prelude::*;
 
+pub mod btn;
+use btn::DeleteButton;
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ResultListType {
     DocSearch,
@@ -9,6 +12,7 @@ pub enum ResultListType {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ResultListData {
+    pub id: String,
     pub domain: Option<String>,
     pub title: String,
     pub description: String,
@@ -20,6 +24,7 @@ pub struct ResultListData {
 impl From<&LensResult> for ResultListData {
     fn from(x: &LensResult) -> Self {
         ResultListData {
+            id: x.title.clone(),
             description: x.description.clone(),
             domain: None,
             result_type: ResultListType::LensSearch,
@@ -33,6 +38,7 @@ impl From<&LensResult> for ResultListData {
 impl From<&SearchResult> for ResultListData {
     fn from(x: &SearchResult) -> Self {
         ResultListData {
+            id: x.doc_id.clone(),
             description: x.description.clone(),
             domain: Some(x.domain.clone()),
             result_type: ResultListType::DocSearch,
@@ -127,6 +133,7 @@ pub fn search_result_component(props: &SearchResultProps) -> Html {
 
             html! {
                 <div class={component_styles}>
+                    <DeleteButton doc_id={result.id.clone()} />
                     {url_link}
                     <h2 class={"text-lg truncate py-1"}>
                         {result.title.clone()}

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -26,6 +26,9 @@ extern "C" {
     #[wasm_bindgen(js_name = "onFocus")]
     pub async fn on_focus(callback: &Closure<dyn Fn()>);
 
+    #[wasm_bindgen(js_name = "onRefreshResults")]
+    pub async fn on_refresh_results(callback: &Closure<dyn Fn()>);
+
     #[wasm_bindgen(js_name = "openResult", catch)]
     pub async fn open(url: String) -> Result<(), JsValue>;
 

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -11,6 +11,9 @@ use crate::pages::{SearchPage, StatsPage};
 
 #[wasm_bindgen(module = "/public/glue.js")]
 extern "C" {
+    #[wasm_bindgen(js_name = "deleteDoc", catch)]
+    pub async fn delete_doc(id: String) -> Result<(), JsValue>;
+
     #[wasm_bindgen(js_name = "searchDocs", catch)]
     pub async fn search_docs(lenses: JsValue, query: String) -> Result<JsValue, JsValue>;
 

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -10,19 +10,6 @@ use crate::components::{ResultListData, SearchResultItem, SelectedLens};
 use crate::events;
 use crate::{on_clear_search, on_focus, resize_window, search_docs, search_lenses};
 
-#[function_component(DeleteButton)]
-fn delete_btn() -> Html {
-    html! {
-        <div class="float-right pl-4 pr-0 h-28">
-            <button class="text-red-600">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                </svg>
-            </button>
-        </div>
-    }
-}
-
 #[function_component(SearchPage)]
 pub fn search_page() -> Html {
     // Lens related data + results

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -10,6 +10,19 @@ use crate::components::{ResultListData, SearchResultItem, SelectedLens};
 use crate::events;
 use crate::{on_clear_search, on_focus, resize_window, search_docs, search_lenses};
 
+#[function_component(DeleteButton)]
+fn delete_btn() -> Html {
+    html! {
+        <div class="float-right pl-4 pr-0 h-28">
+            <button class="text-red-600">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+            </button>
+        </div>
+    }
+}
+
 #[function_component(SearchPage)]
 pub fn search_page() -> Html {
     // Lens related data + results

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -8,7 +8,7 @@ use shared::response;
 
 use crate::components::{ResultListData, SearchResultItem, SelectedLens};
 use crate::events;
-use crate::{on_clear_search, on_focus, resize_window, search_docs, search_lenses};
+use crate::{on_clear_search, on_focus, on_refresh_results, resize_window, search_docs, search_lenses};
 
 #[function_component(SearchPage)]
 pub fn search_page() -> Html {
@@ -115,6 +115,24 @@ pub fn search_page() -> Html {
                 }
             }) as Box<dyn Fn()>);
             on_focus(&cb).await;
+            cb.forget();
+        });
+    }
+
+    {
+        // Refresh search results
+        let query = query.clone();
+        spawn_local(async move {
+            let cb = Closure::wrap(Box::new(move || {
+                let document = gloo::utils::document();
+                if let Some(el) = document.get_element_by_id("searchbox") {
+                    let el: HtmlInputElement = el.unchecked_into();
+                    query.set("".into());
+                    query.set(el.value());
+                }
+            }) as Box<dyn Fn()>);
+
+            on_refresh_results(&cb).await;
             cb.forget();
         });
     }

--- a/crates/shared/src/response.rs
+++ b/crates/shared/src/response.rs
@@ -34,6 +34,7 @@ pub struct SearchMeta {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SearchResult {
+    pub doc_id: String,
     pub domain: String,
     pub title: String,
     pub description: String,

--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -25,6 +25,9 @@ pub trait Rpc {
     #[rpc(name = "crawl_stats")]
     fn crawl_stats(&self) -> BoxFuture<Result<CrawlStats>>;
 
+    #[rpc(name = "delete_doc")]
+    fn delete_doc(&self, id: String) -> BoxFuture<Result<()>>;
+
     #[rpc(name = "toggle_pause")]
     fn toggle_pause(&self) -> BoxFuture<Result<AppStatus>>;
 
@@ -33,4 +36,5 @@ pub trait Rpc {
 
     #[rpc(name = "search_lenses")]
     fn search_lenses(&self, query: SearchLensesParam) -> BoxFuture<Result<SearchLensesResp>>;
+
 }

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -29,6 +29,10 @@ impl Rpc for SpyglassRPC {
         Box::pin(route::crawl_stats(self.state.clone()))
     }
 
+    fn delete_doc(&self, id: String) -> BoxFuture<Result<()>> {
+        Box::pin(route::delete_doc(self.state.clone(), id))
+    }
+
     fn toggle_pause(&self) -> BoxFuture<Result<AppStatus>> {
         Box::pin(route::toggle_pause(self.state.clone()))
     }

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -44,12 +44,14 @@ pub async fn search(state: AppState, search_req: request::SearchParam) -> Result
     for (score, doc_addr) in docs {
         let retrieved = searcher.doc(doc_addr).unwrap();
 
+        let doc_id = retrieved.get_first(fields.id).unwrap();
         let domain = retrieved.get_first(fields.domain).unwrap();
         let title = retrieved.get_first(fields.title).unwrap();
         let description = retrieved.get_first(fields.description).unwrap();
         let url = retrieved.get_first(fields.url).unwrap();
 
         let result = SearchResult {
+            doc_id: doc_id.as_text().unwrap().to_string(),
             domain: domain.as_text().unwrap().to_string(),
             title: title.as_text().unwrap().to_string(),
             description: description.as_text().unwrap().to_string(),

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -219,3 +219,19 @@ pub async fn search_lenses(
 
     Ok(SearchLensesResp { results })
 }
+
+#[instrument(skip(state))]
+pub async fn delete_doc(
+    state: AppState,
+    id: String
+) -> Result<()> {
+    if let Ok(mut writer) = state.index.writer.lock() {
+        if let Err(e) = Searcher::delete(&mut writer, &id) {
+            log::error!("Unable to delete doc {} due to {}", id, e);
+        } else {
+            let _ = writer.commit();
+        }
+    }
+
+    Ok(())
+}

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -96,3 +96,23 @@ pub async fn crawl_stats<'r>(
         }
     }
 }
+
+#[tauri::command]
+pub async fn delete_doc<'r>(
+    _: tauri::Window,
+    rpc: State<'_, rpc::RpcMutex>,
+    id: &str,
+) -> Result<(), String> {
+    let mut rpc = rpc.lock().await;
+    match rpc
+        .client
+        .call_method::<(String,), ()>("delete_docs", "", (id.into(),)).await {
+
+        Ok(_) => Ok(()),
+        Err(err) => {
+            log::error!("Error sending RPC: {}", err);
+            rpc.reconnect().await;
+            Ok(())
+        }
+    }
+}

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -99,16 +99,19 @@ pub async fn crawl_stats<'r>(
 
 #[tauri::command]
 pub async fn delete_doc<'r>(
-    _: tauri::Window,
+    window: tauri::Window,
     rpc: State<'_, rpc::RpcMutex>,
     id: &str,
 ) -> Result<(), String> {
     let mut rpc = rpc.lock().await;
     match rpc
         .client
-        .call_method::<(String,), ()>("delete_docs", "", (id.into(),)).await {
+        .call_method::<(String,), ()>("delete_doc", "", (id.into(),)).await {
 
-        Ok(_) => Ok(()),
+        Ok(_) => {
+            let _ = window.emit("refresh_results", true);
+            Ok(())
+        },
         Err(err) => {
             log::error!("Error sending RPC: {}", err);
             rpc.reconnect().await;

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -58,6 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cmd::search_lenses,
             cmd::resize_window,
             cmd::crawl_stats,
+            cmd::delete_doc,
         ])
         .menu(menu::get_app_menu())
         .system_tray(SystemTray::new().with_menu(menu::get_tray_menu(&config)))


### PR DESCRIPTION
Occasionally we'll crawl something that has been 404'd, rather than wait for the crawler to crawl the page again, this adds a little button to each search result to allow users to delete it.

<p align="center">
<img width="650" alt="Screen Shot 2022-05-25 at 11 37 13 PM" src="https://user-images.githubusercontent.com/146222/170431926-68c5650e-719e-4122-8c98-ca74f972e5e7.png">
</p>

- Add space for a future action bar on the right of search results.
- Add a trash can button to delete the document.