### PR TITLE
bugfix(macos): Fix swapping spaces on window activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,6 +4311,7 @@ name = "spyglass-app"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "cocoa",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "log",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -35,6 +35,9 @@ tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std"] }
 url = "2.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.24"
+
 [features]
 default = [ "custom-protocol" ]
 custom-protocol = [ "tauri/custom-protocol" ]


### PR DESCRIPTION
There was an annoying bug where activating the search bar would switch to the space the app was opened in vs moving the window to the active space.