### PR TITLE
Bugfixes, https -> http fallback, & more.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,20 +727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,12 +1103,12 @@ checksum = "25c7df09945d65ea8d70b3321547ed414bbc540aad5bac6883d021b970f35b04"
 
 [[package]]
 name = "fastfield_codecs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e8bfa31546b4ace05092c9db8d251d7bbc298a384875a08c945a473de4f1f"
+checksum = "8dff2ee906bb242438742b5ecac909c0719cbd9db546f6c3d9ac86bd93f5b07e"
 dependencies = [
  "tantivy-bitpacker",
- "tantivy-common 0.1.0",
+ "tantivy-common",
 ]
 
 [[package]]
@@ -2841,6 +2827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
+name = "oneshot"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b8d98df258e762e901eb4349d66d5a5f5a7a994db8df82ff596011773be535"
+dependencies = [
+ "loom",
+]
+
+[[package]]
 name = "open"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "ownedbytes"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfa208b217a39411d78b85427792e4c1bc40508acbcefd2836e765f44a5c99e"
+checksum = "e2981bd7cfb2a70e6c50083c60561275a269fc7458f151c53b126ec1b15cc040"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -4637,25 +4632,23 @@ dependencies = [
 
 [[package]]
 name = "tantivy"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264c2549892aa83975386a924ef8d0b8e909674c837d37ea58b4bd8739495c6e"
+checksum = "08d3da9d47a874779d5a97c5f01c2d0a85fc96e38ed6d51ad21a3cf6d6eb8c47"
 dependencies = [
  "async-trait",
  "base64",
  "bitpacking",
  "byteorder",
  "census",
- "chrono",
  "crc32fast",
- "crossbeam",
+ "crossbeam-channel",
  "downcast-rs",
  "fail",
  "fastdivide",
  "fastfield_codecs",
  "fnv",
  "fs2",
- "futures 0.3.21",
  "htmlescape",
  "itertools",
  "levenshtein_automata",
@@ -4667,6 +4660,7 @@ dependencies = [
  "murmurhash32",
  "num_cpus",
  "once_cell",
+ "oneshot",
  "ownedbytes",
  "pretty_assertions",
  "rayon",
@@ -4677,35 +4671,27 @@ dependencies = [
  "smallvec",
  "stable_deref_trait",
  "tantivy-bitpacker",
- "tantivy-common 0.2.0",
+ "tantivy-common",
  "tantivy-fst",
  "tantivy-query-grammar",
  "tempfile",
  "thiserror",
- "uuid 0.8.2",
+ "time 0.3.9",
+ "uuid 1.1.1",
  "winapi",
 ]
 
 [[package]]
 name = "tantivy-bitpacker"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d10a5ed75437a4f6bbbba67601cd5adab8d71f5188b677055381f0f36064f2"
-
-[[package]]
-name = "tantivy-common"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760e44073e328f4ea3f38660da9ba2598a19ad5ad4149cfb89ad89b4d5ee88d9"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "tantivy-common"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2078cd12c7e46eb2cd66ec813eac8472e0f9dfe816f26159effceffd2dbe4793"
+checksum = "90f95c862d26a32e1fdb161ab139c5a3bba221f5fac512af40034e13e25f3131"
+
+[[package]]
+name = "tantivy-common"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec19155b3ed963ae1653bc4995ab8175281f68400c39081205ae25b53fd9750"
 dependencies = [
  "byteorder",
  "ownedbytes",
@@ -4724,11 +4710,13 @@ dependencies = [
 
 [[package]]
 name = "tantivy-query-grammar"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466e0218472a9b276a73e38b2571ac02f9a1b270b4481c9cd8cc23a63d1307e9"
+checksum = "5d6bbdce99f2b8dcbe24ee25acffb36a2b45b31344531374df1008f6a64bb583"
 dependencies = [
  "combine",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -5073,6 +5061,7 @@ dependencies = [
  "itoa 1.0.2",
  "libc",
  "num_threads",
+ "serde",
 ]
 
 [[package]]

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -200,8 +200,8 @@ impl Config {
         self.data_dir().join("index")
     }
 
-    pub fn logs_dir(&self) -> PathBuf {
-        self.data_dir().join("logs")
+    pub fn logs_dir() -> PathBuf {
+        Self::default_data_dir().join("logs")
     }
 
     pub fn prefs_dir() -> PathBuf {
@@ -225,7 +225,7 @@ impl Config {
 
         // Gracefully handle issues loading user settings/lenses
         let user_settings = Self::load_user_settings().unwrap_or_else(|err| {
-            log::warn!("Invalid user settings file! Reason: {}", err);
+            log::error!("Invalid user settings file! Reason: {}", err);
             Default::default()
         });
 
@@ -240,7 +240,7 @@ impl Config {
         let index_dir = config.index_dir();
         fs::create_dir_all(&index_dir).expect("Unable to create index folder");
 
-        let logs_dir = config.logs_dir();
+        let logs_dir = Config::logs_dir();
         fs::create_dir_all(&logs_dir).expect("Unable to create logs folder");
 
         let lenses_dir = config.lenses_dir();

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 shared = { path = "../shared" }
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "sqlite", "chrono"] }
-tantivy = "0.17"
+tantivy = "0.18"
 tendril = "0.4.2"
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -21,7 +21,6 @@ use robots::check_resource_rules;
 
 // TODO: Make this configurable by domain
 const FETCH_DELAY_MS: i64 = 1000 * 60 * 60 * 24;
-static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
 #[derive(Debug, Default, Clone)]
 pub struct CrawlResult {

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use addr::parse_domain_name;
 use chrono::prelude::*;
 use chrono::Duration;
-use reqwest::{Client, StatusCode};
+use reqwest::StatusCode;
 use sha2::{Digest, Sha256};
 use url::{Host, Url};
 
@@ -15,6 +15,7 @@ pub mod bootstrap;
 pub mod robots;
 
 use crate::crawler::bootstrap::create_archive_url;
+use crate::fetch::HTTPClient;
 use crate::scraper::html_to_text;
 use robots::check_resource_rules;
 
@@ -80,7 +81,7 @@ fn normalize_href(url: &str, href: &str) -> Option<String> {
 
 #[derive(Debug, Clone)]
 pub struct Crawler {
-    pub client: Client,
+    pub client: HTTPClient,
 }
 
 impl Default for Crawler {
@@ -128,23 +129,15 @@ fn determine_canonical(original: &Url, extracted: &Url) -> String {
 
 impl Crawler {
     pub fn new() -> Self {
-        let client = Client::builder()
-            .user_agent(APP_USER_AGENT)
-            // TODO: Make configurable
-            .timeout(std::time::Duration::from_secs(60))
-            .build()
-            .expect("Unable to create reqwest client");
-
-        Crawler { client }
+        Crawler { client: HTTPClient::new() }
     }
+
     /// Fetches and parses the content of a page.
     async fn crawl(&self, url: &Url) -> CrawlResult {
-        // Force HTTPs
-        let mut url = url.clone();
-        url.set_scheme("https").unwrap();
+        let url = url.clone();
 
         // Fetch & store page data.
-        let res = self.client.get(url.as_str()).send().await;
+        let res = self.client.get(&url).await;
         if res.is_err() {
             // Unable to connect to host
             return CrawlResult {

--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -163,9 +163,7 @@ pub async fn check_resource_rules(
     }
 
     // Check the content-type of the URL, only crawl HTML pages for now
-    let res = client.head(&url).await;
-
-    match res {
+    match client.head(url).await {
         Err(err) => {
             log::info!("Unable to check content-type: {}", err.to_string());
             return Ok(false);

--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -2,15 +2,17 @@
 /// See the following for more details about robots.txt files:
 /// - https://developers.google.com/search/docs/advanced/robots/intro
 /// - https://www.robotstxt.org/robotstxt.html
+use regex::RegexSet;
+use reqwest::StatusCode;
+use std::convert::From;
+use url::Url;
+
 use entities::models::resource_rule;
 use entities::regex::{regex_for_robots, WildcardType};
 use entities::sea_orm::prelude::*;
 use entities::sea_orm::{DatabaseConnection, Set};
 
-use regex::RegexSet;
-use reqwest::{Client, StatusCode};
-use std::convert::From;
-use url::Url;
+use crate::fetch::HTTPClient;
 
 #[derive(Clone, Debug)]
 pub struct ParsedRule {
@@ -95,7 +97,7 @@ pub fn parse(domain: &str, txt: &str) -> Vec<ParsedRule> {
 // Checks whether we're allow to crawl this url
 pub async fn check_resource_rules(
     db: &DatabaseConnection,
-    client: &Client,
+    client: &HTTPClient,
     url: &Url,
 ) -> anyhow::Result<bool> {
     let domain = url.host_str().unwrap();
@@ -108,9 +110,10 @@ pub async fn check_resource_rules(
 
     if rules.is_empty() {
         log::info!("No rules found for <{}>, fetching robot.txt", domain);
+        let mut robots_url = url.clone();
+        robots_url.set_path("/robots.txt");
 
-        let robots_url = format!("https://{}/robots.txt", domain);
-        let res = client.get(robots_url).send().await;
+        let res = client.get(&robots_url).await;
         match res {
             Err(err) => log::error!("Unable to check robots.txt {}", err.to_string()),
             Ok(res) => {
@@ -160,7 +163,7 @@ pub async fn check_resource_rules(
     }
 
     // Check the content-type of the URL, only crawl HTML pages for now
-    let res = client.head(url.as_str()).send().await;
+    let res = client.head(&url).await;
 
     match res {
         Err(err) => {

--- a/crates/spyglass/src/fetch.rs
+++ b/crates/spyglass/src/fetch.rs
@@ -1,4 +1,5 @@
-use reqwest::{Client, Response};
+use anyhow::Result;
+use reqwest::{Client, Error, Response};
 use url::Url;
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
@@ -10,26 +11,74 @@ pub struct HTTPClient {
     client: Client
 }
 
+impl Default for HTTPClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HTTPClient {
     pub fn new() -> Self {
         let client = reqwest::Client::builder()
             .user_agent(APP_USER_AGENT)
             // TODO: Make configurable
-            .timeout(std::time::Duration::from_secs(60))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("Unable to create reqwest client");
 
         HTTPClient { client }
     }
 
-    pub async fn head(&self, url: &Url) -> anyhow::Result<Response> {
-        todo!()
+    pub async fn head(&self, url: &Url) -> Result<Response, Error> {
+        let mut url = url.clone();
+
+        url.set_scheme("https").expect("Unable to set scheme to HTTPS");
+        let mut res = self.client.head(url.clone()).send().await;
+        if let Err(e) = &res {
+            if e.is_request() {
+                url.set_scheme("http").expect("Unable to set scheme to HTTP");
+                res = self.client.head(url).send().await;
+            }
+        }
+
+        res
     }
 
-    pub async fn get(&self, url: &Url) -> anyhow::Result<Response> {
+    pub async fn get(&self, url: &Url) -> Result<Response, Error> {
         let mut url = url.clone();
-        url.set_scheme("https").unwrap();
 
-        todo!()
+        // Attempt HTTPS first, if that fails switch to HTTP
+        url.set_scheme("https").expect("Unable to set scheme to HTTPS");
+        let mut res = self.client.get(url.clone()).send().await;
+        if let Err(e) = &res {
+            if e.is_request() {
+                url.set_scheme("http").expect("Unable to set scheme to HTTP");
+                res = self.client.get(url).send().await;
+            }
+        }
+
+        res
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::HTTPClient;
+    use url::Url;
+
+    #[tokio::test]
+    async fn test_http_switch() {
+        let client = HTTPClient::new();
+        let url = Url::parse("https://paulgraham.com").unwrap();
+
+        let res = client.get(&url).await;
+        if res.is_err() {
+            dbg!(&res);
+        }
+
+        assert!(res.is_ok());
+        // Should have switched to HTTP
+        let resp = res.unwrap();
+        assert_eq!(resp.url().scheme(), "http");
     }
 }

--- a/crates/spyglass/src/fetch.rs
+++ b/crates/spyglass/src/fetch.rs
@@ -1,0 +1,35 @@
+use reqwest::{Client, Response};
+use url::Url;
+
+static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
+
+/// A wrapper around reqwest that for HTTP related queries that handles retries,
+/// downgrading from HTTPS -> HTTP, 429 too many requests, etc.
+#[derive(Clone, Debug)]
+pub struct HTTPClient {
+    client: Client
+}
+
+impl HTTPClient {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            // TODO: Make configurable
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .expect("Unable to create reqwest client");
+
+        HTTPClient { client }
+    }
+
+    pub async fn head(&self, url: &Url) -> anyhow::Result<Response> {
+        todo!()
+    }
+
+    pub async fn get(&self, url: &Url) -> anyhow::Result<Response> {
+        let mut url = url.clone();
+        url.set_scheme("https").unwrap();
+
+        todo!()
+    }
+}

--- a/crates/spyglass/src/lib.rs
+++ b/crates/spyglass/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate html5ever;
 
 pub mod crawler;
+pub mod fetch;
 pub mod scraper;
 pub mod search;
 pub mod state;

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -19,9 +19,7 @@ mod importer;
 use crate::api::start_api_ipc;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::new();
-
-    let file_appender = tracing_appender::rolling::daily(config.logs_dir(), "server.log");
+    let file_appender = tracing_appender::rolling::daily(Config::logs_dir(), "server.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     let subscriber = tracing_subscriber::registry()
@@ -36,6 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
     LogTracer::init()?;
 
+    let config = Config::new();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("spyglass-backend")

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -94,9 +94,7 @@ pub async fn manager_task(
                 }
             }
             // ignore everything else
-            _ => {
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            }
+            _ => {}
         }
     }
 }

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -35,7 +35,7 @@ use window::{show_crawl_stats_window, show_lens_manager_window};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::new();
 
-    let file_appender = tracing_appender::rolling::daily(config.logs_dir(), "client.log");
+    let file_appender = tracing_appender::rolling::daily(Config::logs_dir(), "client.log");
     let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
 
     let subscriber = tracing_subscriber::registry()
@@ -160,7 +160,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .on_system_tray_event(|app, event| {
             if let SystemTrayEvent::MenuItemClick { id, .. } = event {
-                let config = app.state::<Config>();
                 let item_handle = app.tray_handle().get_item(&id);
                 let window = app.get_window("main").unwrap();
 
@@ -184,7 +183,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     menu::OPEN_LENS_MANAGER => {
                         show_lens_manager_window(app);
                     }
-                    menu::OPEN_LOGS_FOLDER => open_folder(config.logs_dir()),
+                    menu::OPEN_LOGS_FOLDER => open_folder(Config::logs_dir()),
                     menu::OPEN_SETTINGS_FOLDER => open_folder(Config::prefs_dir()),
                     menu::SHOW_CRAWL_STATUS => {
                         show_crawl_stats_window(app);


### PR DESCRIPTION
## 🐛 Bugfixes
- Properly handle duplicate URLs when using `enqueue_all`
- No logs while user settings was being loaded

## Updates
- Handle https -> http fallback for sites that don't support HTTPs, closes #67 
- Basic handling of 429 error codes, closes #68 

