### PR TITLE
Set always on top for windows

### DIFF
--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -36,6 +36,7 @@ pub fn show_window(window: &Window) {
     window.emit("focus_window", true).unwrap();
     window.show().unwrap();
     window.set_focus().unwrap();
+    window.set_always_on_top(true).unwrap();
     center_window(window);
 }
 


### PR DESCRIPTION
Dearest Reviewer,

Reading the api for tauri I found and tested this change locally. All windows now show above my fullscreen windows.

Fixes: https://github.com/a5huynh/spyglass/issues/74

Thank you for your work on this project.
Becker