### PR TITLE
Handle internet outage

### DIFF
--- a/crates/client/public/glue.js
+++ b/crates/client/public/glue.js
@@ -6,7 +6,7 @@ if (window.__TAURI__) {
 }
 
 export async function escape() {
-    return await invoke("escape");
+    return await invoke('escape');
 }
 
 export async function onClearSearch(callback) {
@@ -26,41 +26,45 @@ export async function on_refresh_lens_manager(callback) {
 }
 
 export async function crawlStats() {
-    return await invoke("crawl_stats");
+    return await invoke('crawl_stats');
 }
 
 export async function deleteDoc(id) {
-    return await invoke("delete_doc", { id });
+    return await invoke('delete_doc', { id });
 }
 
 export async function install_lens(downloadUrl) {
-    return await invoke("install_lens", { downloadUrl })
+    return await invoke('install_lens', { downloadUrl })
 }
 
 export async function listInstalledLenses() {
-    return await invoke("list_installed_lenses");
+    return await invoke('list_installed_lenses');
 }
 
 export async function listInstallableLenses() {
-    return await invoke("list_installable_lenses");
+    return await invoke('list_installable_lenses');
+}
+
+export async function network_change(isOffline) {
+    return await invoke('network_change', { isOffline });
 }
 
 export async function searchDocs(lenses, query) {
-    return await invoke("search_docs", { lenses, query });
+    return await invoke('search_docs', { lenses, query });
 }
 
 export async function searchLenses(query) {
-    return await invoke("search_lenses", { query });
+    return await invoke('search_lenses', { query });
 }
 
 export async function openResult(url) {
-    return await invoke("open_result", { url });
+    return await invoke('open_result', { url });
 }
 
 export async function openLensFolder() {
-    return await invoke("open_lens_folder");
+    return await invoke('open_lens_folder');
 }
 
 export async function resizeWindow(height) {
-    return await invoke("resize_window", { height });
+    return await invoke('resize_window', { height });
 }

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -144,8 +144,8 @@ impl Crawler {
             log::warn!("Unable to fetch <{}> due to {}", &url, res.unwrap_err());
             // Unable to connect to host
             return CrawlResult {
-                // Service unavilable
-                status: 503_u16,
+                // TODO: Have our own internal error codes we can refer too later on
+                status: 600_u16,
                 url: url.to_string(),
                 ..Default::default()
             };

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -241,7 +241,12 @@ impl Crawler {
 
         // Crawl & save the data
         let mut result = self.crawl(&url).await;
-        log::info!("fetched {} {:?}", result.status, result.url);
+        if result.is_bad_request() {
+            log::warn!("issue fetching {} {:?}", result.status, result.url);
+        } else {
+            log::trace!("fetched {} {:?}", result.status, result.url);
+        }
+
         // Check to see if a canonical URL was found, if not use the original
         // bootstrapped URL
         if crawl.crawl_type == crawl_queue::CrawlType::Bootstrap {

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cmd::install_lens,
             cmd::list_installable_lenses,
             cmd::list_installed_lenses,
+            cmd::network_change,
             cmd::open_lens_folder,
             cmd::open_result,
             cmd::resize_window,


### PR DESCRIPTION
- Closes #52 
- Listen to offline/online events and pause/unpause the crawler accordingly
- Log failures w/ fetching so we can better debug issues