### PR TITLE
updater: trigger update check every 6 hours

### DIFF
--- a/crates/tauri/src/constants.rs
+++ b/crates/tauri/src/constants.rs
@@ -1,11 +1,13 @@
 pub const INPUT_WIDTH: f64 = 640.0;
 pub const INPUT_Y: f64 = 128.0;
 
+// Check for a new version every 6 hours. 60 seconds * 60 minutes * 6 hours
+pub const VERSION_CHECK_INTERVAL_S: u64 = 60 * 60 * 6;
+
 pub const APP_USER_AGENT: &str = "spyglass (github.com/a5huynh/spyglass)";
 pub const DISCORD_JOIN_URL: &str = "https://discord.gg/663wPVBSTB";
 pub const LENS_DIRECTORY_INDEX_URL: &str =
     "https://raw.githubusercontent.com/spyglass-search/lens-box/main/index.ron";
-pub const VERSION_CHECK_URL: &str = "https://api.github.com/repos/a5huynh/spyglass/releases";
 
 pub const STATS_WIN_NAME: &str = "crawl_stats";
 pub const LENS_MANAGER_WIN_NAME: &str = "lens_manager";


### PR DESCRIPTION
By default the update check only happens on startup. Since spyglass is meant to run for a very long time, add in a check every 6 hours for an update