### PR TITLE
tweak: save a little space by not storing the entire HTML page in the index

### DIFF
--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -191,7 +191,8 @@ impl Crawler {
             title: parse_result.title,
             url: canonical_url,
             links: parse_result.links,
-            raw: Some(raw_body.to_string()),
+            // No need to store the raw HTML for now.
+            raw: None, // Some(raw_body.to_string()),
         }
     }
 


### PR DESCRIPTION
we don't use this for anything at the moment. In the future, we should store this in a cache & refetch if necessary