### PR TITLE
bugfix: correctly track URLs w/ query params in fetch history

### DIFF
--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -12,7 +12,7 @@ use shared::response::{
     SearchResult, SearchResults,
 };
 
-use entities::models::{crawl_queue, indexed_document, lens};
+use entities::models::{crawl_queue, fetch_history, indexed_document, lens};
 use entities::sea_orm::{prelude::*, sea_query, QueryOrder, Set};
 use libspyglass::plugin::PluginCommand;
 use libspyglass::search::Searcher;
@@ -214,6 +214,11 @@ pub async fn list_queue(state: AppState) -> Result<response::ListQueue> {
 pub async fn recrawl_domain(state: AppState, domain: String) -> Result<()> {
     log::info!("handling recrawl domain: {}", domain);
     let db = &state.db;
+
+    let _ = fetch_history::Entity::delete_many()
+        .filter(fetch_history::Column::Domain.eq(domain.clone()))
+        .exec(db)
+        .await;
 
     let res = crawl_queue::Entity::update_many()
         .col_expr(

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1.0"
 shared = { path = "../shared" }
 strum = "0.24"
 strum_macros = "0.24"
-tauri = { version = "1.0.2", features = ["api-all", "devtools", "process-command-api", "notification", "system-tray", "updater"] }
+tauri = { version = "1.0.2", features = ["api-all", "devtools", "notification", "process-command-api", "system-tray", "updater"] }
 tokio = "1"
 tokio-retry = "0.3"
 tracing = "0.1"


### PR DESCRIPTION
- Clear fetch history for domain on recrawl domain (prevented recrawls from happening if recently fetched).
- Track URL query params as part of fetch history URL