### PR TITLE
Delete seed_url during domain deletion

### DIFF
--- a/crates/entities/src/models/bootstrap_queue.rs
+++ b/crates/entities/src/models/bootstrap_queue.rs
@@ -71,3 +71,19 @@ pub async fn enqueue(
     new_row.insert(db).await?;
     Ok(())
 }
+
+pub async fn dequeue(
+    db: &DatabaseConnection,
+    seed_url: &str,
+) -> anyhow::Result<(), sea_orm::DbErr> {
+    let res = Entity::find()
+        .filter(Column::SeedUrl.eq(seed_url))
+        .one(db)
+        .await?;
+
+    if let Some(res) = res {
+        res.delete(db).await?;
+    }
+
+    Ok(())
+}

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -30,6 +30,11 @@ async fn check_and_bootstrap(
                 return true;
             }
         }
+    } else {
+        log::info!(
+            "bootstrap queue already contains seed url: {}, skipping",
+            seed_url
+        );
     }
 
     false


### PR DESCRIPTION
When a domain is deleted from the crawl_status page, it previously wasn't removed from the bootstrap_queue. This means the domain would never be re-bootstrapped, therefore never being indexed again.

This adds a `dequeue()` method to the bootstrap_queue, and dequeues the seed_url as part of the `delete_domain()` call