### PR TITLE
bugfix: better handling of sidecar start/restarts

### DIFF
--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -103,10 +103,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
-            // Start up backend (only in release mode)
-            #[cfg(not(debug_assertions))]
-            rpc::check_and_start_backend();
-
             let window = app.get_window("main").expect("Main window not found");
             let _ = window.set_skip_taskbar(true);
 

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -15,7 +15,7 @@ pub type RpcMutex = Arc<Mutex<RpcClient>>;
 pub struct RpcClient {
     pub client: TypedClient,
     pub endpoint: String,
-    pub sidecar_handle: Option<JoinHandle<()>>
+    pub sidecar_handle: Option<JoinHandle<()>>,
 }
 
 async fn connect(endpoint: &str) -> Result<TypedClient, ()> {
@@ -52,7 +52,7 @@ impl RpcClient {
         RpcClient {
             client,
             endpoint: endpoint.clone(),
-            sidecar_handle
+            sidecar_handle,
         }
     }
 
@@ -110,7 +110,7 @@ impl RpcClient {
                     CommandEvent::Terminated(payload) => {
                         sentry::capture_error(&std::io::Error::new(
                             std::io::ErrorKind::BrokenPipe,
-                            format!("sidecar terminated: {:?}", payload.clone()),
+                            format!("sidecar terminated: {:?}", payload),
                         ));
                         log::error!("sidecar terminated: {:?}", payload);
                         return;

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use shared::rpc::gen_ipc_path;
 use tauri::api::process::{Command, CommandEvent};
+use tauri::async_runtime::JoinHandle;
 use tokio::sync::Mutex;
 use tokio_retry::strategy::ExponentialBackoff;
 use tokio_retry::Retry;
@@ -14,35 +15,7 @@ pub type RpcMutex = Arc<Mutex<RpcClient>>;
 pub struct RpcClient {
     pub client: TypedClient,
     pub endpoint: String,
-}
-
-pub fn check_and_start_backend() {
-    tauri::async_runtime::spawn(async move {
-        let (mut rx, _) = Command::new_sidecar("spyglass-server")
-            .expect("failed to create `spyglass-server` binary command")
-            .spawn()
-            .expect("Failed to spawn sidecar");
-
-        while let Some(event) = rx.recv().await {
-            match event {
-                CommandEvent::Error(message) => {
-                    sentry::capture_error(&std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        message.clone(),
-                    ));
-                    log::error!("sidecar error: {}", message);
-                }
-                CommandEvent::Terminated(payload) => {
-                    sentry::capture_error(&std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        format!("sidecar terminated: {:?}", payload.clone()),
-                    ));
-                    log::error!("sidecar terminated: {:?}", payload)
-                }
-                _ => {}
-            }
-        }
-    });
+    pub sidecar_handle: Option<JoinHandle<()>>
 }
 
 async fn connect(endpoint: &str) -> Result<TypedClient, ()> {
@@ -69,9 +42,17 @@ impl RpcClient {
             .await
             .expect("Unable to connect to spyglass backend!");
 
+        // Only startup & manage sidecar in release mode.
+        #[cfg(not(debug_assertions))]
+        let sidecar_handle = Some(RpcClient::check_and_start_backend());
+
+        #[cfg(debug_assertions)]
+        let sidecar_handle = None;
+
         RpcClient {
             client,
             endpoint: endpoint.clone(),
+            sidecar_handle
         }
     }
 
@@ -92,12 +73,51 @@ impl RpcClient {
     }
 
     pub async fn reconnect(&mut self) {
-        log::info!("Attempting to restart backend");
         // Attempt to reconnect
-        check_and_start_backend();
+        if let Some(sidecar) = &self.sidecar_handle {
+            log::info!("child process killed");
+            tauri::api::process::kill_children();
+
+            log::info!("Attempting to restart backend");
+            sidecar.abort();
+            self.sidecar_handle = Some(RpcClient::check_and_start_backend());
+        }
+
+        log::info!("Trying to reconnect to backend...");
         self.client = try_connect(&self.endpoint)
             .await
             .expect("Unable to connect to spyglass backend!");
-        log::info!("restarted");
+        log::info!("Connected!");
+    }
+
+    pub fn check_and_start_backend() -> JoinHandle<()> {
+        tauri::async_runtime::spawn(async move {
+            let (mut rx, _) = Command::new_sidecar("spyglass-server")
+                .expect("failed to create `spyglass-server` binary command")
+                .spawn()
+                .expect("Failed to spawn sidecar");
+
+            while let Some(event) = rx.recv().await {
+                match event {
+                    CommandEvent::Error(message) => {
+                        sentry::capture_error(&std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            message.clone(),
+                        ));
+                        log::error!("sidecar error: {}", message);
+                        return;
+                    }
+                    CommandEvent::Terminated(payload) => {
+                        sentry::capture_error(&std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            format!("sidecar terminated: {:?}", payload.clone()),
+                        ));
+                        log::error!("sidecar terminated: {:?}", payload);
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        })
     }
 }


### PR DESCRIPTION
On updates / restarts the backend sometimes locks. This manages that interaction better & gracefullly handles termination/restart