### PR TITLE
bugfix: dont hold up main UI thread on pause/unpause

### DIFF
--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -49,7 +49,7 @@ pub trait Rpc {
     fn search_lenses(&self, query: SearchLensesParam) -> BoxFuture<Result<SearchLensesResp>>;
 
     #[rpc(name = "toggle_pause")]
-    fn toggle_pause(&self) -> BoxFuture<Result<AppStatus>>;
+    fn toggle_pause(&self) -> BoxFuture<Result<bool>>;
 
     #[rpc(name = "toggle_plugin")]
     fn toggle_plugin(&self, name: String) -> BoxFuture<Result<()>>;

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -57,7 +57,7 @@ impl Rpc for SpyglassRPC {
         Box::pin(route::search_lenses(self.state.clone(), query))
     }
 
-    fn toggle_pause(&self) -> BoxFuture<Result<AppStatus>> {
+    fn toggle_pause(&self) -> BoxFuture<Result<bool>> {
         Box::pin(route::toggle_pause(self.state.clone()))
     }
 

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -365,18 +365,16 @@ pub async fn search_lenses(
 }
 
 #[instrument(skip(state))]
-pub async fn toggle_pause(state: AppState) -> jsonrpc_core::Result<AppStatus> {
+pub async fn toggle_pause(state: AppState) -> jsonrpc_core::Result<bool> {
     // Scope so that the app_state mutex is correctly released.
-    {
-        let app_state = &state.app_state;
-        let mut paused_status = app_state.entry("paused".into()).or_insert("false".into());
+    let app_state = &state.app_state;
+    let mut paused_status = app_state.entry("paused".into()).or_insert("false".into());
 
-        let current_status = paused_status.to_string() == "true";
-        let updated_status = !current_status;
-        *paused_status = updated_status.to_string();
-    }
+    let current_status = paused_status.to_string() == "true";
+    let updated_status = !current_status;
+    *paused_status = updated_status.to_string();
 
-    _get_current_status(state.clone()).await
+    Ok(updated_status)
 }
 
 #[instrument(skip(state))]

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -281,7 +281,7 @@ pub async fn network_change(
             if should_toggle {
                 let _ = rpc
                     .client
-                    .call_method::<Value, response::AppStatus>("toggle_pause", "", Value::Null)
+                    .call_method::<Value, bool>("toggle_pause", "", Value::Null)
                     .await;
             }
         }

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -266,7 +266,7 @@ async fn pause_crawler(app: AppHandle, menu_id: String) {
             let item_handle = app.tray_handle().get_item(&menu_id);
             let _ = item_handle.set_title(new_label);
             let _ = item_handle.set_enabled(true);
-        },
+        }
         Err(err) => {
             log::error!("Error sending RPC: {}", err);
             rpc.reconnect().await;


### PR DESCRIPTION
Closes #63 

- Moves the pause/unpause request off the main UI thread. Will still hold up other RPC requests while the backend processes the request, but shouldn't freeze the UI