### PR TITLE
Fix issue with windows rename method for directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,7 @@ dependencies = [
  "sea-orm-migration",
  "shared",
  "tantivy",
+ "tar",
 ]
 
 [[package]]

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -14,3 +14,4 @@ entities = { path = "../entities" }
 shared = { path = "../shared" }
 tantivy = "0.18"
 rayon = "1.5"
+tar = "0.4"

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -8,6 +8,7 @@ mod m20220508_000001_lens_and_crawl_queue_update;
 mod m20220522_000001_bootstrap_queue_table;
 mod m20220718_000001_add_cols_to_lens;
 mod m20220823_000001_migrate_search_schema;
+mod utils;
 
 pub struct Migrator;
 

--- a/crates/migrations/src/utils/migration_utils.rs
+++ b/crates/migrations/src/utils/migration_utils.rs
@@ -1,0 +1,111 @@
+use std::fs::File;
+use std::io::Result;
+use std::path::PathBuf;
+use std::time::SystemTime;
+use tar::Builder;
+
+// Utility method used to create a tar file from the specified directory.
+// The generated tar file will have the same name as the directory with
+// the utc timestamp and the extension "old" append to it.
+pub fn backup_dir(dir: &PathBuf) -> Result<()> {
+    let prefix = dir.file_name().unwrap();
+    let time_str = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .to_string();
+    // Name of output tar file
+    let output_file = format!("{}.{}.{}", prefix.to_str().unwrap(), time_str, "old");
+
+    let logging_str = output_file.clone();
+
+    // Full path to output tar file
+    let backup_path = dir.parent().unwrap().join(output_file);
+
+    let file_result = File::create(backup_path);
+    if let Err(e) = file_result {
+        println!(
+            "Error generating backup file {:?} for directory {:?}, Error: {:?}",
+            logging_str, dir, e
+        );
+        return Err(e);
+    }
+
+    let file = file_result.unwrap();
+    let mut tar_builder = Builder::new(file);
+
+    let tar_response = tar_builder.append_dir_all(".", dir);
+    if let Err(e) = tar_response {
+        println!("Error adding files to tar, {:?}", e);
+        return Err(e);
+    }
+    return Ok(());
+}
+
+// Utility method replaces the destination directory with the contents of
+// the source directory. Linux/MacOS uses the rename command while windows
+// uses a manual process (Gooooo Windows!!! :( ).
+// Windows Process:
+// 1. Delete destination folder and all contents
+// 2. Recreate empty destination folder
+// 3. Copy each file from source folder into destination folder
+//    3a. Note directories are not currently processed
+// 4. Delete source directory and all contents
+//
+// Linux Process:
+// 1. Delete destination directory and all contents
+// 2. Rename source directory to name used by destination directory
+pub fn replace_dir(source: &PathBuf, dest: &PathBuf) -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        // Step 1 delete destination
+        if let Err(e) = std::fs::remove_dir_all(dest) {
+            return Err(e);
+        }
+
+        // Step 2 recreate dest directory
+        if let Err(e) = std::fs::create_dir(dest) {
+            return Err(e);
+        }
+
+        // Step 3 Copy files from source to destination
+        for entry in std::fs::read_dir(source)? {
+            if let Err(e) = entry {
+                println!("Error accessing index File {:?} ", e);
+                return Err(e);
+            }
+
+            let path = entry?.path();
+            if path.is_file() {
+                match path.file_name() {
+                    Some(filename) => {
+                        let dest_path = dest.join(filename);
+                        println!("  copy: {:?} -> {:?}", &path, &dest_path);
+                        std::fs::copy(&path, &dest_path)?;
+                    }
+                    None => {
+                        println!("failed: {:?}", path);
+                    }
+                }
+            }
+        }
+
+        // Step 4 delete source
+        if let Err(e) = std::fs::remove_dir_all(source) {
+            return Err(e);
+        }
+
+        return Ok(());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Step 1 delete destination
+        if let Err(e) = std::fs::remove_dir_all(dest) {
+            return Err(e);
+        }
+
+        // Step 2 Rename
+        return std::fs::rename(source, dest);
+    }
+}

--- a/crates/migrations/src/utils/migration_utils.rs
+++ b/crates/migrations/src/utils/migration_utils.rs
@@ -39,7 +39,7 @@ pub fn backup_dir(dir: &PathBuf) -> Result<()> {
         println!("Error adding files to tar, {:?}", e);
         return Err(e);
     }
-    return Ok(());
+    Ok(())
 }
 
 // Utility method replaces the destination directory with the contents of
@@ -59,15 +59,11 @@ pub fn replace_dir(source: &PathBuf, dest: &PathBuf) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
         // Step 1 delete destination
-        if let Err(e) = std::fs::remove_dir_all(dest) {
-            return Err(e);
-        }
+        std::fs::remove_dir_all(dest)?;
 
         // Step 2 recreate dest directory
-        if let Err(e) = std::fs::create_dir(dest) {
-            return Err(e);
-        }
-
+        std::fs::create_dir(dest)?;
+        
         // Step 3 Copy files from source to destination
         for entry in std::fs::read_dir(source)? {
             if let Err(e) = entry {
@@ -91,11 +87,9 @@ pub fn replace_dir(source: &PathBuf, dest: &PathBuf) -> Result<()> {
         }
 
         // Step 4 delete source
-        if let Err(e) = std::fs::remove_dir_all(source) {
-            return Err(e);
-        }
+        std::fs::remove_dir_all(source)?;
 
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -106,6 +100,6 @@ pub fn replace_dir(source: &PathBuf, dest: &PathBuf) -> Result<()> {
         }
 
         // Step 2 Rename
-        return std::fs::rename(source, dest);
+        std::fs::rename(source, dest)
     }
 }

--- a/crates/migrations/src/utils/mod.rs
+++ b/crates/migrations/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod migration_utils;


### PR DESCRIPTION
The schema migration process used the standard rename function for replacing the index directories. This function does not work with directories on windows. Created a utility to tar up the old index files and move the new index into place. A conditional compile is used to keep using the rename on non windows os. 