### PR TITLE
feature: support for more complex search filters & filters from plugins

### DIFF
--- a/assets/plugins/chrome-importer/manifest.ron
+++ b/assets/plugins/chrome-importer/manifest.ron
@@ -4,7 +4,7 @@
     description: "Sync bookmarks / history from Chrome into Spyglass",
     version: "1",
     plugin_type: Lens,
-    trigger: "chrome",
+    trigger: "bookmarks",
     // User settings w/ the default value, this will be added the plugin environment
     user_settings: {
         "CHROME_DATA_FOLDER": (

--- a/assets/plugins/chrome-importer/manifest.ron
+++ b/assets/plugins/chrome-importer/manifest.ron
@@ -4,6 +4,7 @@
     description: "Sync bookmarks / history from Chrome into Spyglass",
     version: "1",
     plugin_type: Lens,
+    trigger: "chrome",
     // User settings w/ the default value, this will be added the plugin environment
     user_settings: {
         "CHROME_DATA_FOLDER": (

--- a/assets/plugins/firefox-importer/manifest.ron
+++ b/assets/plugins/firefox-importer/manifest.ron
@@ -4,6 +4,7 @@
     description: "Sync bookmarks / history from Firefox into Spyglass",
     version: "1",
     plugin_type: Lens,
+    trigger: "firefox",
     // User settings w/ the default value, this will be added the plugin environment
     user_settings: {
         "FIREFOX_DATA_FOLDER": (

--- a/assets/plugins/firefox-importer/manifest.ron
+++ b/assets/plugins/firefox-importer/manifest.ron
@@ -4,7 +4,7 @@
     description: "Sync bookmarks / history from Firefox into Spyglass",
     version: "1",
     plugin_type: Lens,
-    trigger: "firefox",
+    trigger: "bookmarks",
     // User settings w/ the default value, this will be added the plugin environment
     user_settings: {
         "FIREFOX_DATA_FOLDER": (

--- a/assets/plugins/local-file-indexer/manifest.ron
+++ b/assets/plugins/local-file-indexer/manifest.ron
@@ -4,6 +4,7 @@
     description: "Crawl & index local files. Currently only supports `.md` and `.txt` extensions. Add folders in your user settings to get started!",
     version: "1",
     plugin_type: Lens,
+    trigger: "files",
     // User settings w/ the default value, this will be added the plugin environment
     user_settings: {
         "FOLDERS_LIST": (

--- a/crates/entities/src/models/lens.rs
+++ b/crates/entities/src/models/lens.rs
@@ -7,7 +7,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum, Serialize)]
 #[sea_orm(rs_type = "String", db_type = "String(Some(1))")]
 pub enum LensType {
-    // A simple lens with URLs & rules
+    // A simple lens with URLs & rules that acts as a "filter"
     #[sea_orm(string_value = "Simple")]
     Simple,
     // A plugin based lens where queueing & rules are dynamic given whatever the

--- a/crates/entities/src/models/lens.rs
+++ b/crates/entities/src/models/lens.rs
@@ -92,7 +92,11 @@ pub async fn add_or_enable(
         // Update description / etc.
         updated.author = Set(lens.author.to_string());
         updated.version = Set(lens.version.to_string());
-        updated.trigger = Set(Some(lens.trigger.to_string()));
+        if lens.trigger.is_empty() {
+            updated.trigger = Set(Some(lens.name.clone()));
+        } else {
+            updated.trigger = Set(Some(lens.trigger.to_string()));
+        }
         match &lens.description {
             Some(desc) => updated.description = Set(Some(desc.clone())),
             None => updated.description = Set(None),

--- a/crates/entities/src/models/lens.rs
+++ b/crates/entities/src/models/lens.rs
@@ -86,10 +86,13 @@ pub async fn add_or_enable(
 
     // If it already exists & is not a plugin, simply enable it.
     if let Some(existing) = exists {
+        log::info!("updating lens: {}", lens.name);
+
         let mut updated: ActiveModel = existing.clone().into();
         // Update description / etc.
         updated.author = Set(lens.author.to_string());
         updated.version = Set(lens.version.to_string());
+        updated.trigger = Set(Some(lens.trigger.to_string()));
         match &lens.description {
             Some(desc) => updated.description = Set(Some(desc.clone())),
             None => updated.description = Set(None),

--- a/crates/entities/src/models/mod.rs
+++ b/crates/entities/src/models/mod.rs
@@ -10,21 +10,19 @@ pub mod resource_rule;
 
 use shared::config::Config;
 
-#[cfg(test)]
-fn db_uri(_: &Config) -> String {
-    "sqlite::memory:".to_string()
-}
+pub async fn create_connection(
+    config: &Config,
+    is_test: bool,
+) -> anyhow::Result<DatabaseConnection> {
+    let db_uri = if is_test {
+        "sqlite::memory:".to_string()
+    } else {
+        format!(
+            "sqlite://{}?mode=rwc",
+            config.data_dir().join("db.sqlite").to_str().unwrap()
+        )
+    };
 
-#[cfg(not(test))]
-fn db_uri(config: &Config) -> String {
-    format!(
-        "sqlite://{}?mode=rwc",
-        config.data_dir().join("db.sqlite").to_str().unwrap()
-    )
-}
-
-pub async fn create_connection(config: &Config) -> anyhow::Result<DatabaseConnection> {
-    let db_uri = db_uri(config);
     // See https://www.sea-ql.org/SeaORM/docs/install-and-config/connection
     // for more connection options
     let mut opt = ConnectOptions::new(db_uri);
@@ -41,7 +39,7 @@ mod test {
     #[tokio::test]
     async fn test_create_connection() {
         let config = Config::default();
-        let res = create_connection(&config).await;
+        let res = create_connection(&config, true).await;
         assert!(res.is_ok());
     }
 }

--- a/crates/entities/src/schema.rs
+++ b/crates/entities/src/schema.rs
@@ -21,6 +21,7 @@ pub fn mapping_to_schema(mapping: &SchemaMapping) -> Schema {
     schema_builder.build()
 }
 
+#[derive(Clone)]
 pub struct DocFields {
     pub id: Field,
     pub domain: Field,

--- a/crates/entities/src/test.rs
+++ b/crates/entities/src/test.rs
@@ -9,7 +9,7 @@ use crate::models::{
 #[allow(dead_code)]
 pub async fn setup_test_db() -> DatabaseConnection {
     let config = Config::default();
-    let db = create_connection(&config).await.unwrap();
+    let db = create_connection(&config, true).await.unwrap();
     setup_schema(&db).await.expect("Unable to create tables");
 
     db

--- a/crates/entities/src/test.rs
+++ b/crates/entities/src/test.rs
@@ -9,7 +9,7 @@ use crate::models::{
 #[allow(dead_code)]
 pub async fn setup_test_db() -> DatabaseConnection {
     let config = Config::default();
-    let db = create_connection(&config, true).await.unwrap();
+    let db = create_connection(&config).await.unwrap();
     setup_schema(&db).await.expect("Unable to create tables");
 
     db

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -29,7 +29,7 @@ impl Migrator {
     pub async fn run_migrations() -> Result<(), DbErr> {
         let config = Config::new();
 
-        let db = create_connection(&config)
+        let db = create_connection(&config, false)
             .await
             .expect("Unable to connect to db");
 

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -29,7 +29,7 @@ impl Migrator {
     pub async fn run_migrations() -> Result<(), DbErr> {
         let config = Config::new();
 
-        let db = create_connection(&config, false)
+        let db = create_connection(&config)
             .await
             .expect("Unable to connect to db");
 

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -13,7 +13,7 @@ pub const MAX_DOMAIN_INFLIGHT: u32 = 100;
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub lenses: HashMap<String, Lens>,
+    pub lenses: HashMap<String, LensConfig>,
     pub user_settings: UserSettings,
 }
 
@@ -54,21 +54,23 @@ impl LensRule {
 /// Contexts are a set of domains/URLs/etc. that restricts a search space to
 /// improve results.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct Lens {
-    #[serde(default = "Lens::default_author")]
+pub struct LensConfig {
+    #[serde(default = "LensConfig::default_author")]
     pub author: String,
     pub name: String,
     pub description: Option<String>,
     pub domains: Vec<String>,
     pub urls: Vec<String>,
     pub version: String,
-    #[serde(default = "Lens::default_is_enabled")]
+    #[serde(default = "LensConfig::default_is_enabled")]
     pub is_enabled: bool,
     #[serde(default)]
     pub rules: Vec<LensRule>,
+    #[serde(default)]
+    pub trigger: String,
 }
 
-impl Lens {
+impl LensConfig {
     fn default_author() -> String {
         "Unknown".to_string()
     }

--- a/crates/shared/src/plugin.rs
+++ b/crates/shared/src/plugin.rs
@@ -21,6 +21,8 @@ pub struct PluginConfig {
     pub author: String,
     pub description: String,
     pub version: String,
+    // Trigger command for this plugin (if a lens),
+    pub trigger: String,
     #[serde(default)]
     pub path: Option<PathBuf>,
     pub plugin_type: PluginType,

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -5,6 +5,12 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 pub use shims::*;
 
+#[derive(Serialize, Deserialize)]
+pub enum SearchFilter {
+    // No filter
+    None,
+}
+
 #[macro_export]
 macro_rules! register_plugin {
     ($t:ty) => {
@@ -27,6 +33,13 @@ macro_rules! register_plugin {
                 }
             })
         }
+
+        #[no_mangle]
+        pub fn search_filter() {
+            STATE.with(|state| {
+                state.borrow_mut().search_filter();
+            })
+        }
     };
 }
 pub trait SpyglassPlugin {
@@ -35,6 +48,12 @@ pub trait SpyglassPlugin {
     fn load(&mut self);
     /// Request plugin for updates
     fn update(&mut self, event: PluginEvent);
+    /// Optional function.
+    /// Only called for Lens plugins, request a set of filters to apply to a search.
+    /// If not implemented, no filter is applied to the search.
+    fn search_filter(&mut self) {
+        let _ = object_to_stdout(&SearchFilter::None);
+    }
 }
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -5,10 +5,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 pub use shims::*;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum SearchFilter {
     // No filter
     None,
+    URLRegex(String),
 }
 
 #[macro_export]
@@ -37,7 +38,8 @@ macro_rules! register_plugin {
         #[no_mangle]
         pub fn search_filter() {
             STATE.with(|state| {
-                state.borrow_mut().search_filter();
+                let filters = state.borrow_mut().search_filter();
+                let _ = object_to_stdout(&filters);
             })
         }
     };
@@ -51,8 +53,8 @@ pub trait SpyglassPlugin {
     /// Optional function.
     /// Only called for Lens plugins, request a set of filters to apply to a search.
     /// If not implemented, no filter is applied to the search.
-    fn search_filter(&mut self) {
-        let _ = object_to_stdout(&SearchFilter::None);
+    fn search_filter(&mut self) -> Vec<SearchFilter> {
+        vec![SearchFilter::None]
     }
 }
 

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 pub use shims::*;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SearchFilter {
     // No filter
     None,

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -273,7 +273,14 @@ pub async fn search(state: AppState, search_req: request::SearchParam) -> Result
     let searcher = index.reader.searcher();
 
     let applied: Vec<SearchFilter> = futures::stream::iter(search_req.lenses.iter())
-        .filter_map(|trigger| lens_to_filters(state.clone(), trigger))
+        .filter_map(|trigger| async {
+            let vec = lens_to_filters(state.clone(), trigger).await;
+            if vec.is_empty() {
+                None
+            } else {
+                Some(vec)
+            }
+        })
         // Gather search filters
         .collect::<Vec<Vec<SearchFilter>>>()
         .await

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -14,6 +14,7 @@ use shared::response::{
 
 use entities::models::{bootstrap_queue, crawl_queue, fetch_history, indexed_document, lens};
 use entities::schema::{DocFields, SearchDocument};
+use entities::sea_orm::Condition;
 use entities::sea_orm::{prelude::*, sea_query, QueryOrder, Set};
 
 use libspyglass::plugin::PluginCommand;

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -9,7 +9,6 @@ use entities::models::lens::LensType;
 use entities::models::{bootstrap_queue, crawl_queue, fetch_history, indexed_document, lens};
 use entities::schema::{DocFields, SearchDocument};
 use entities::sea_orm::{prelude::*, sea_query, sea_query::Expr, QueryOrder, Set};
-use shared::regex::{regex_for_domain, regex_for_prefix};
 use shared::request;
 use shared::response::{
     AppStatus, CrawlStats, LensResult, PluginResult, QueueStatus, SearchLensesResp, SearchMeta,
@@ -18,6 +17,7 @@ use shared::response::{
 use spyglass_plugin::SearchFilter;
 
 use libspyglass::plugin::PluginCommand;
+use libspyglass::search::lens::lens_to_filters;
 use libspyglass::search::Searcher;
 use libspyglass::state::AppState;
 use libspyglass::task::Command;
@@ -269,52 +269,11 @@ pub async fn recrawl_domain(state: AppState, domain: String) -> Result<()> {
 pub async fn search(state: AppState, search_req: request::SearchParam) -> Result<SearchResults> {
     let fields = DocFields::as_fields();
 
-    let index = state.index;
+    let index = &state.index;
     let searcher = index.reader.searcher();
 
     let applied: Vec<SearchFilter> = futures::stream::iter(search_req.lenses.iter())
-        .filter_map(|trigger| async {
-            // Find the lenses that were triggered
-            let result = lens::Entity::find()
-                .filter(lens::Column::Trigger.eq(trigger.clone()))
-                .one(&state.db)
-                .await;
-
-            // Based on the lens type, either use filters defined by the configuration
-            // or ask the plugin for the search filter.
-            if let Ok(Some(lens)) = result {
-                match lens.lens_type {
-                    // Load lens configuration from files
-                    lens::LensType::Simple => {
-                        let mut filters: Vec<SearchFilter> = Vec::new();
-                        if let Some(lens_config) = state.lenses.get(&lens.name) {
-                            for domain in &lens_config.domains {
-                                filters.push(SearchFilter::URLRegex(regex_for_domain(domain)));
-                            }
-
-                            for prefix in &lens_config.urls {
-                                filters.push(SearchFilter::URLRegex(regex_for_prefix(prefix)));
-                            }
-                        }
-
-                        Some(filters)
-                    }
-                    // Ask plugin for any filter information
-                    lens::LensType::Plugin => {
-                        let manager = state.plugin_manager.lock().await;
-                        if let Some(plugin) = manager.find_by_name(lens.name) {
-                            let filters = plugin.search_filters().await;
-                            return Some(filters);
-                        }
-
-                        // plugin not enabled?
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        })
+        .filter_map(|trigger| lens_to_filters(state.clone(), trigger))
         // Gather search filters
         .collect::<Vec<Vec<SearchFilter>>>()
         .await
@@ -322,8 +281,6 @@ pub async fn search(state: AppState, search_req: request::SearchParam) -> Result
         .into_iter()
         .flatten()
         .collect::<Vec<SearchFilter>>();
-
-    dbg!(&applied);
 
     let docs =
         Searcher::search_with_lens(state.db.clone(), &applied, &index.reader, &search_req.query)

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -337,7 +337,12 @@ pub async fn search_lenses(
     let mut results = Vec::new();
 
     let query_results = lens::Entity::find()
-        .filter(lens::Column::Name.like(&format!("%{}%", &param.query)))
+        // Filter either by the name of the lens or the trigger
+        .filter(
+            Condition::any()
+                .add(lens::Column::Name.like(&format!("%{}%", &param.query)))
+                .add(lens::Column::Trigger.like(&format!("%{}%", &param.query))),
+        )
         .filter(lens::Column::IsEnabled.eq(true))
         .filter(lens::Column::LensType.eq(LensType::Simple))
         .order_by_asc(lens::Column::Name)

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -278,11 +278,13 @@ pub async fn search(state: AppState, search_req: request::SearchParam) -> Result
     }
 
     let docs = Searcher::search_with_lens(
+        state.db.clone(),
         &lenses,
         &index.reader,
         &search_req.lenses,
         &search_req.query,
-    );
+    )
+    .await;
 
     let mut results: Vec<SearchResult> = Vec::new();
     for (score, doc_addr) in docs {

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use jsonrpc_core::{Error, ErrorCode, Result};
+use std::collections::HashMap;
 use tracing::instrument;
 use url::Url;
 
@@ -13,7 +13,7 @@ use entities::models::crawl_queue::CrawlStatus;
 use entities::models::lens::LensType;
 use entities::models::{bootstrap_queue, crawl_queue, fetch_history, indexed_document, lens};
 use entities::schema::{DocFields, SearchDocument};
-use entities::sea_orm::{prelude::*, sea_query, QueryOrder, Set, sea_query::Expr};
+use entities::sea_orm::{prelude::*, sea_query, sea_query::Expr, QueryOrder, Set};
 
 use libspyglass::plugin::PluginCommand;
 use libspyglass::search::Searcher;

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use entities::models::crawl_queue::{self, EnqueueSettings};
 use entities::sea_orm::DatabaseConnection;
-use shared::config::{Lens, UserSettings};
+use shared::config::{LensConfig, UserSettings};
 
 // Using Internet Archive's CDX because it's faster & more reliable.
 const ARCHIVE_CDX_ENDPOINT: &str = "https://web.archive.org/cdx/search/cdx";
@@ -111,7 +111,7 @@ async fn fetch_cdx_page(
 /// from the Internet Archive. We then crawl their archived stuff as fast as possible
 /// locally to bring the index up to date.
 pub async fn bootstrap(
-    lens: &Lens,
+    lens: &LensConfig,
     db: &DatabaseConnection,
     settings: &UserSettings,
     url: &str,

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -99,15 +99,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn start_backend(state: &mut AppState, config: &Config) {
-    // TODO: Implement user-friendly start-up wizard
-    // if state.config.user_settings.run_wizard {
-    //     // Import data from Firefox
-    //     // TODO: Ask user what browser/profiles to import on first startup.
-    //     let importer = FirefoxImporter::new(&config);
-    //     let _ = importer.import(&state).await;
-    // }
-
-    // Initialize crawl_queue, set all in-flight tasks to queued.
+    // Initialize crawl_queue, requeue all in-flight tasks.
     crawl_queue::reset_processing(&state.db).await;
     if let Err(e) = lens::reset(&state.db).await {
         log::error!("Unable to reset lenses: {}", e);
@@ -192,7 +184,7 @@ async fn start_backend(state: &mut AppState, config: &Config) {
     }
 
     // Plugin server
-    let pm_handle = tokio::spawn(plugin::plugin_manager(
+    let pm_handle = tokio::spawn(plugin::plugin_event_loop(
         state.clone(),
         config.clone(),
         plugin_cmd_tx.clone(),

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -346,7 +346,7 @@ pub async fn plugin_load(
                 name: plug.name.clone(),
                 author: plug.author,
                 description: Some(plug.description.clone()),
-                trigger: plug.name.clone(),
+                trigger: plug.trigger.clone(),
                 ..Default::default()
             };
 

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -15,7 +15,7 @@ use wasmer::{Instance, Module, Store, WasmerEnv};
 use wasmer_wasi::{Pipe, WasiEnv, WasiState};
 
 use entities::models::lens;
-use shared::config::Config;
+use shared::config::{Config, LensConfig};
 use shared::plugin::{PluginConfig, PluginType};
 use spyglass_plugin::{consts::env, PluginEvent, PluginSubscription};
 
@@ -341,16 +341,16 @@ pub async fn plugin_load(
         // Enable plugins that are lenses, this is the only type right so technically they
         // all will be enabled as a lens.
         if plug.plugin_type == PluginType::Lens {
-            match lens::add_or_enable(
-                &state.db,
-                &plug.name,
-                &plug.author,
-                Some(&plug.description),
-                &plug.version,
-                lens::LensType::Plugin,
-            )
-            .await
-            {
+            let plug = plug.clone();
+            let lens_config = LensConfig {
+                name: plug.name.clone(),
+                author: plug.author,
+                description: Some(plug.description.clone()),
+                trigger: plug.name.clone(),
+                ..Default::default()
+            };
+
+            match lens::add_or_enable(&state.db, &lens_config, lens::LensType::Plugin).await {
                 Ok(is_new) => {
                     log::info!("loaded lens {}, new? {}", plug.name, is_new)
                 }

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -7,7 +7,7 @@ use migration::sea_orm::DatabaseConnection;
 use shared::regex::{regex_for_robots, WildcardType};
 use url::Url;
 
-use shared::config::{Config, Lens, LensRule, UserSettings};
+use shared::config::{Config, LensConfig, LensRule, UserSettings};
 
 use crate::crawler::bootstrap;
 use crate::search::Searcher;
@@ -15,7 +15,7 @@ use crate::state::AppState;
 
 /// Check if we've already bootstrapped a prefix / otherwise add it to the queue.
 async fn check_and_bootstrap(
-    lens: &Lens,
+    lens: &LensConfig,
     db: &DatabaseConnection,
     user_settings: &UserSettings,
     seed_url: &str,
@@ -54,7 +54,7 @@ pub async fn read_lenses(state: &AppState, config: &Config) -> anyhow::Result<()
         let path = entry.path();
         if path.is_file() && path.extension().unwrap_or_default() == "ron" {
             if let Ok(file_contents) = fs::read_to_string(path) {
-                match ron::from_str::<Lens>(&file_contents) {
+                match ron::from_str::<LensConfig>(&file_contents) {
                     Err(err) => log::error!("Unable to load lens {:?}: {}", entry.path(), err),
                     Ok(lens) => {
                         if lens.is_enabled {
@@ -72,7 +72,7 @@ pub async fn read_lenses(state: &AppState, config: &Config) -> anyhow::Result<()
 /// Loop through lenses in the AppState. Update our internal db & bootstrap anything
 /// that hasn't been bootstrapped.
 pub async fn load_lenses(state: AppState) {
-    let mut new_lenses: Vec<Lens> = Vec::new();
+    let mut new_lenses: Vec<LensConfig> = Vec::new();
     for entry in state.lenses.iter() {
         let lens = entry.value();
         // Have we added this lens to the database?

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -208,43 +208,50 @@ pub async fn load_lenses(state: AppState) {
 
 /// Utility function to map a trigger to the matching lens(es) & convert that into
 /// search filters ready to be applied to a search.
-pub async fn lens_to_filters(state: AppState, trigger: &str) -> Option<Vec<SearchFilter>> {
+pub async fn lens_to_filters(state: AppState, trigger: &str) -> Vec<SearchFilter> {
     // Find the lenses that were triggered
-    let result = lens::Entity::find()
+    // NOTE: Users can combine lenses together but giving them the same trigger label
+    let results = lens::Entity::find()
         .filter(lens::Column::Trigger.eq(trigger))
-        .one(&state.db)
-        .await;
+        .all(&state.db)
+        .await
+        .ok();
 
     // Based on the lens type, either use filters defined by the configuration
     // or ask the plugin for the search filter.
-    if let Ok(Some(lens)) = result {
-        match lens.lens_type {
-            // Load lens configuration from files
-            lens::LensType::Simple => {
-                if let Some(lens_config) = state.lenses.get(&lens.name) {
-                    return Some(
-                        lens_config
-                            .into_regexes()
-                            .into_iter()
-                            .map(SearchFilter::URLRegex)
-                            .collect::<Vec<SearchFilter>>(),
-                    );
+    let mut filters = Vec::new();
+    if let Some(result) = results {
+        for lens in result {
+            match lens.lens_type {
+                // Load lens configuration from files
+                lens::LensType::Simple => {
+                    if let Some(lens_config) = state.lenses.get(&lens.name) {
+                        filters.extend(
+                            lens_config
+                                .into_regexes()
+                                .into_iter()
+                                .map(SearchFilter::URLRegex)
+                                .collect::<Vec<SearchFilter>>(),
+                        );
+                    }
                 }
-            }
-            // Ask plugin for any filter information
-            lens::LensType::Plugin => {
-                let manager = state.plugin_manager.lock().await;
-                if let Some(plugin) = manager.find_by_name(lens.name) {
-                    let filters = plugin.search_filters().await;
-                    return Some(filters);
+                // Ask plugin for any filter information
+                lens::LensType::Plugin => {
+                    let manager = state.plugin_manager.lock().await;
+                    if let Some(plugin) = manager.find_by_name(lens.name) {
+                        filters.extend(plugin.search_filters().await);
+                    }
                 }
             }
         }
     }
 
-    // lens removed / plugin not enabled?
-    log::warn!("unable to find lens for trigger: {}", trigger);
-    None
+    if filters.is_empty() {
+        // lens remove? Plugin disabled?
+        log::warn!("No filters found for trigger: {}", trigger);
+    }
+
+    filters
 }
 
 #[cfg(test)]

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -76,16 +76,7 @@ pub async fn load_lenses(state: AppState) {
     for entry in state.lenses.iter() {
         let lens = entry.value();
         // Have we added this lens to the database?
-        match lens::add_or_enable(
-            &state.db,
-            &lens.name,
-            &lens.author,
-            lens.description.as_ref(),
-            &lens.version,
-            lens::LensType::Simple,
-        )
-        .await
-        {
+        match lens::add_or_enable(&state.db, lens, lens::LensType::Simple).await {
             Ok(is_new) => {
                 log::info!("loaded lens {}, new? {}", lens.name, is_new);
                 new_lenses.push(lens.clone());

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -311,7 +311,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_basic_lense_search() {
-        let db = create_connection(&Config::default()).await.unwrap();
+        let db = create_connection(&Config::default(), true).await.unwrap();
         let lens = LensConfig {
             name: "wiki".to_string(),
             domains: vec!["en.wikipedia.org".to_string()],
@@ -330,7 +330,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_url_lens_search() {
-        let db = create_connection(&Config::default()).await.unwrap();
+        let db = create_connection(&Config::default(), true).await.unwrap();
 
         let lens = LensConfig {
             name: "wiki".to_string(),
@@ -350,7 +350,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_singular_url_lens_search() {
-        let db = create_connection(&Config::default()).await.unwrap();
+        let db = create_connection(&Config::default(), true).await.unwrap();
 
         let lens = LensConfig {
             name: "wiki".to_string(),

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -16,7 +16,7 @@ use crate::search::query::build_query;
 use crate::search::utils::ff_to_string;
 use entities::schema::{DocFields, SearchDocument};
 use entities::sea_orm::DatabaseConnection;
-use shared::config::Lens;
+use shared::config::LensConfig;
 use shared::regex::{regex_for_domain, regex_for_prefix};
 
 pub mod lens;
@@ -142,7 +142,7 @@ impl Searcher {
 
     pub async fn search_with_lens(
         _db: DatabaseConnection,
-        lenses: &HashMap<String, Lens>,
+        lenses: &HashMap<String, LensConfig>,
         reader: &IndexReader,
         applied_lens: &[String],
         query_string: &str,
@@ -236,7 +236,7 @@ impl Searcher {
 mod test {
     use crate::search::{IndexPath, Searcher};
     use entities::models::create_connection;
-    use shared::config::{Config, Lens};
+    use shared::config::{Config, LensConfig};
     use std::collections::HashMap;
 
     fn _build_test_index(searcher: &mut Searcher) {
@@ -320,7 +320,7 @@ mod test {
     #[tokio::test]
     pub async fn test_basic_lense_search() {
         let db = create_connection(&Config::default(), true).await.unwrap();
-        let lens = Lens {
+        let lens = LensConfig {
             name: "wiki".to_string(),
             domains: vec!["en.wikipedia.org".to_string()],
             urls: Vec::new(),
@@ -345,7 +345,7 @@ mod test {
     pub async fn test_url_lens_search() {
         let db = create_connection(&Config::default(), true).await.unwrap();
 
-        let lens = Lens {
+        let lens = LensConfig {
             name: "wiki".to_string(),
             domains: Vec::new(),
             urls: vec!["https://en.wikipedia.org/mice".to_string()],
@@ -370,7 +370,7 @@ mod test {
     pub async fn test_singular_url_lens_search() {
         let db = create_connection(&Config::default(), true).await.unwrap();
 
-        let lens = Lens {
+        let lens = LensConfig {
             name: "wiki".to_string(),
             domains: Vec::new(),
             urls: vec!["https://en.wikipedia.org/mice$".to_string()],

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -230,6 +230,7 @@ mod test {
     use crate::search::{IndexPath, Searcher};
     use entities::models::create_connection;
     use shared::config::{Config, LensConfig};
+    use spyglass_plugin::SearchFilter;
 
     fn _build_test_index(searcher: &mut Searcher) {
         let writer = &mut searcher.writer.lock().unwrap();
@@ -319,7 +320,11 @@ mod test {
             ..Default::default()
         };
 
-        let applied_lens = vec![lens.clone()];
+        let applied_lens = lens
+            .into_regexes()
+            .into_iter()
+            .map(SearchFilter::URLRegex)
+            .collect();
         let mut searcher = Searcher::with_index(&IndexPath::Memory);
         _build_test_index(&mut searcher);
 
@@ -339,7 +344,11 @@ mod test {
             ..Default::default()
         };
 
-        let applied_lens = vec![lens.clone()];
+        let applied_lens = lens
+            .into_regexes()
+            .into_iter()
+            .map(SearchFilter::URLRegex)
+            .collect();
         let mut searcher = Searcher::with_index(&IndexPath::Memory);
         _build_test_index(&mut searcher);
 
@@ -359,8 +368,11 @@ mod test {
             ..Default::default()
         };
 
-        let applied_lens = vec![lens.clone()];
-        lenses.insert("wiki".to_string(), lens.clone());
+        let applied_lens = lens
+            .into_regexes()
+            .into_iter()
+            .map(SearchFilter::URLRegex)
+            .collect();
 
         let mut searcher = Searcher::with_index(&IndexPath::Memory);
         _build_test_index(&mut searcher);

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -311,7 +311,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_basic_lense_search() {
-        let db = create_connection(&Config::default(), true).await.unwrap();
+        let db = create_connection(&Config::default()).await.unwrap();
         let lens = LensConfig {
             name: "wiki".to_string(),
             domains: vec!["en.wikipedia.org".to_string()],
@@ -330,7 +330,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_url_lens_search() {
-        let db = create_connection(&Config::default(), true).await.unwrap();
+        let db = create_connection(&Config::default()).await.unwrap();
 
         let lens = LensConfig {
             name: "wiki".to_string(),
@@ -350,7 +350,7 @@ mod test {
 
     #[tokio::test]
     pub async fn test_singular_url_lens_search() {
-        let db = create_connection(&Config::default(), true).await.unwrap();
+        let db = create_connection(&Config::default()).await.unwrap();
 
         let lens = LensConfig {
             name: "wiki".to_string(),

--- a/crates/spyglass/src/search/query.rs
+++ b/crates/spyglass/src/search/query.rs
@@ -27,6 +27,7 @@ pub fn build_query(fields: DocFields, query_string: &str) -> BooleanQuery {
         .collect();
 
     let mut term_query: QueryVec = Vec::new();
+
     // Boost exact matches to the full query string
     if terms.len() > 1 {
         term_query.push((

--- a/crates/spyglass/src/search/utils.rs
+++ b/crates/spyglass/src/search/utils.rs
@@ -1,16 +1,20 @@
-use tantivy::{DocId, fastfield::MultiValuedFastFieldReader, termdict::TermDictionary};
+use tantivy::{fastfield::MultiValuedFastFieldReader, termdict::TermDictionary, DocId};
 
-pub fn ff_to_string(doc_id: DocId, reader: &MultiValuedFastFieldReader<u64>, terms: &TermDictionary) -> Option<String> {
+pub fn ff_to_string(
+    doc_id: DocId,
+    reader: &MultiValuedFastFieldReader<u64>,
+    terms: &TermDictionary,
+) -> Option<String> {
     let mut vals = Vec::new();
     reader.get_vals(doc_id, &mut vals);
 
     if let Some(term_id) = vals.pop() {
         let mut bytes = Vec::new();
-        if let Err(_) = terms.ord_to_term(term_id, &mut bytes) {
+        if terms.ord_to_term(term_id, &mut bytes).is_err() {
             return None;
         }
 
-        return String::from_utf8(bytes.to_vec()).ok()
+        return String::from_utf8(bytes.to_vec()).ok();
     }
 
     None

--- a/crates/spyglass/src/search/utils.rs
+++ b/crates/spyglass/src/search/utils.rs
@@ -1,0 +1,17 @@
+use tantivy::{DocId, fastfield::MultiValuedFastFieldReader, termdict::TermDictionary};
+
+pub fn ff_to_string(doc_id: DocId, reader: &MultiValuedFastFieldReader<u64>, terms: &TermDictionary) -> Option<String> {
+    let mut vals = Vec::new();
+    reader.get_vals(doc_id, &mut vals);
+
+    if let Some(term_id) = vals.pop() {
+        let mut bytes = Vec::new();
+        if let Err(_) = terms.ord_to_term(term_id, &mut bytes) {
+            return None;
+        }
+
+        return String::from_utf8(bytes.to_vec()).ok()
+    }
+
+    None
+}

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -11,13 +11,13 @@ use crate::{
     search::{IndexPath, Searcher},
     task::Command,
 };
-use shared::config::{Config, Lens, UserSettings};
+use shared::config::{Config, LensConfig, UserSettings};
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
     pub app_state: Arc<DashMap<String, String>>,
-    pub lenses: Arc<DashMap<String, Lens>>,
+    pub lenses: Arc<DashMap<String, LensConfig>>,
     pub user_settings: UserSettings,
     pub index: Searcher,
     // Crawler pause control

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -12,6 +12,7 @@ use crate::{
     task::Command,
 };
 use shared::config::{Config, LensConfig, UserSettings};
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
@@ -54,5 +55,67 @@ impl AppState {
             plugin_cmd_tx: Arc::new(Mutex::new(None)),
             plugin_manager: Arc::new(Mutex::new(PluginManager::new())),
         }
+    }
+
+    pub fn builder() -> AppStateBuilder {
+        AppStateBuilder::new()
+    }
+}
+
+#[derive(Default)]
+pub struct AppStateBuilder {
+    db: Option<DatabaseConnection>,
+    index: Option<Searcher>,
+    lenses: Option<Vec<LensConfig>>,
+    user_settings: Option<UserSettings>,
+}
+
+impl AppStateBuilder {
+    pub fn build(&self) -> AppState {
+        let lenses = DashMap::new();
+        if let Some(res) = &self.lenses {
+            for lens in res {
+                lenses.insert(lens.name.clone(), lens.to_owned());
+            }
+        }
+
+        AppState {
+            app_state: Arc::new(DashMap::new()),
+            db: self.db.as_ref().expect("Must set db").to_owned(),
+            user_settings: self
+                .user_settings
+                .as_ref()
+                .expect("Must set user settings")
+                .to_owned(),
+            index: self.index.as_ref().expect("Must set index").to_owned(),
+            lenses: Arc::new(lenses),
+            crawler_cmd_tx: Arc::new(Mutex::new(None)),
+            plugin_cmd_tx: Arc::new(Mutex::new(None)),
+            plugin_manager: Arc::new(Mutex::new(PluginManager::new())),
+        }
+    }
+
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn with_db(&mut self, db: DatabaseConnection) -> &mut Self {
+        self.db = Some(db);
+        self
+    }
+
+    pub fn with_lenses(&mut self, lenses: &Vec<LensConfig>) -> &mut Self {
+        self.lenses = Some(lenses.to_owned());
+        self
+    }
+
+    pub fn with_user_settings(&mut self, user_settings: &UserSettings) -> &mut Self {
+        self.user_settings = Some(user_settings.to_owned());
+        self
+    }
+
+    pub fn with_index(&mut self, index: &IndexPath) -> &mut Self {
+        self.index = Some(Searcher::with_index(index));
+        self
     }
 }

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -7,12 +7,11 @@ use tokio::sync::Mutex;
 use tokio::sync::{broadcast, mpsc};
 
 use crate::{
-    plugin::PluginCommand,
+    plugin::{PluginCommand, PluginManager},
     search::{IndexPath, Searcher},
     task::Command,
 };
 use shared::config::{Config, LensConfig, UserSettings};
-
 #[derive(Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
@@ -24,6 +23,7 @@ pub struct AppState {
     pub crawler_cmd_tx: Arc<Mutex<Option<broadcast::Sender<Command>>>>,
     // Plugin command/control
     pub plugin_cmd_tx: Arc<Mutex<Option<mpsc::Sender<PluginCommand>>>>,
+    pub plugin_manager: Arc<Mutex<PluginManager>>,
 }
 
 impl AppState {
@@ -52,6 +52,7 @@ impl AppState {
             index,
             crawler_cmd_tx: Arc::new(Mutex::new(None)),
             plugin_cmd_tx: Arc::new(Mutex::new(None)),
+            plugin_manager: Arc::new(Mutex::new(PluginManager::new())),
         }
     }
 }

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -28,7 +28,7 @@ pub struct AppState {
 
 impl AppState {
     pub async fn new(config: &Config) -> Self {
-        let db = create_connection(config)
+        let db = create_connection(config, false)
             .await
             .expect("Unable to connect to database");
 

--- a/crates/spyglass/src/state.rs
+++ b/crates/spyglass/src/state.rs
@@ -28,7 +28,7 @@ pub struct AppState {
 
 impl AppState {
     pub async fn new(config: &Config) -> Self {
-        let db = create_connection(config, false)
+        let db = create_connection(config)
             .await
             .expect("Unable to connect to database");
 

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -6,7 +6,7 @@ use url::Url;
 use entities::models::{crawl_queue, indexed_document};
 use entities::sea_orm::prelude::*;
 use entities::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
-use shared::config::{Config, Lens};
+use shared::config::{Config, LensConfig};
 
 use crate::crawler::Crawler;
 use crate::search::{
@@ -134,7 +134,7 @@ async fn _handle_fetch(state: AppState, crawler: Crawler, task: CrawlTask) {
             // Add all valid, non-duplicate, non-indexed links found to crawl queue
             let to_enqueue: Vec<String> = crawl_result.links.into_iter().collect();
 
-            let lenses: Vec<Lens> = state
+            let lenses: Vec<LensConfig> = state
                 .lenses
                 .iter()
                 .map(|entry| entry.value().clone())

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -12,6 +12,8 @@ use migration::Migrator;
 use shared::response::AppStatus;
 use shared::{event::ClientEvent, response};
 
+const TRAY_UPDATE_INTERVAL_S: u64 = 60;
+
 use crate::{
     constants,
     menu::MenuID,
@@ -29,7 +31,7 @@ pub fn init() -> TauriPlugin<Wry> {
                 // Keep system tray stats updated
                 let app_handle = app_handle.clone();
                 tauri::async_runtime::spawn(async move {
-                    let mut interval = time::interval(Duration::from_secs(60));
+                    let mut interval = time::interval(Duration::from_secs(TRAY_UPDATE_INTERVAL_S));
                     loop {
                         update_tray_menu(&app_handle).await;
                         interval.tick().await;

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -112,4 +112,8 @@ impl SpyglassPlugin for Plugin {
             _ => {}
         }
     }
+
+    fn search_filter(&mut self) -> Vec<SearchFilter> {
+        vec![SearchFilter::URLRegex("file://.*".to_string())]
+    }
 }


### PR DESCRIPTION
## ✨ Updates
- Plugins can apply filters to a search. 
    - See changes to `crates/spyglass-plugin/src/lib.rs`
    - See `local-file-indexer` plugin for an example of how this will work.
- Calls to plugin funcs are run as their own async task (perhaps should just be a whole new thread?)
- Sleep added to plugin event loop to unblock plugin manager lock
- Integrating a custom scorer into the search to apply filters using info outside the search schema. 
  - Simplifies search queries and speeds them up for very large lenses w/ lots of regexes.
  - Can apply filters to `url`, `title`, content, etc.
  - Use metadata from crawling/page analysis as potential filters as well.

## ♻️ Refactor
- Plugin manager promoted to `AppState` struct & shared amongst all tasks.
- Renaming `shared::lens::Lens` -> `LensConfig` so we don't confuse it with `entities::models::lens`
- Renaming `plugin_manager` func to more descriptive `plugin_event_loop`
- Support for user changeable "trigger" labels for the lens. By default uses the lens name.

