### PR TITLE
refactor: Publish `spyglass-plugin` & `spyglass-lens` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4866,6 +4866,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "spyglass-lens",
  "strum 0.24.1",
  "strum_macros 0.24.2",
  "url 2.2.2",
@@ -5062,6 +5063,16 @@ dependencies = [
  "web-sys",
  "yew",
  "yew-router",
+]
+
+[[package]]
+name = "spyglass-lens"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "regex",
+ "ron",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "spyglass-lens"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,10 @@ members = [
     "crates/migrations",
     "crates/shared",
     "crates/spyglass",
-    "crates/spyglass-plugin",
     "crates/tauri",
+    # Publically published crates
+    "crates/spyglass-plugin",
+    "crates/spyglass-lens",
     # Default plugins
     "plugins/chrome-importer",
     "plugins/firefox-importer",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -18,4 +18,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
+spyglass-lens = { path = "../spyglass-lens" }
 url = "2.2"

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -4,9 +4,9 @@ use std::path::PathBuf;
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
+pub use spyglass_lens::{LensConfig, LensRule};
 
 use crate::plugin::PluginConfig;
-use crate::regex::{regex_for_domain, regex_for_prefix, regex_for_robots, WildcardType};
 
 pub const MAX_TOTAL_INFLIGHT: u32 = 100;
 pub const MAX_DOMAIN_INFLIGHT: u32 = 100;
@@ -20,80 +20,6 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-/// Different rules that filter out the URLs that would be crawled for a lens
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum LensRule {
-    /// Limits the depth of a URL to a certain depth.
-    /// For example:
-    ///  - LimitURLDepth("https://example.com/", 1) will limit it to https://example.com/<path 1>
-    ///  - LimitURLDepth("https://example.com/", 2) will limit it to https://example.com/<path 1>/<path 2>
-    ///  - etc.
-    LimitURLDepth(String, u8),
-    /// Skips are applied when bootstrapping & crawling
-    SkipURL(String),
-}
-
-impl LensRule {
-    pub fn to_regex(&self) -> String {
-        match &self {
-            LensRule::LimitURLDepth(prefix, max_depth) => {
-                let prefix = prefix.trim_end_matches('/');
-                let regex = format!("^{}/?(/[^/]+/?){{0, {}}}$", prefix, max_depth);
-                regex
-            }
-            LensRule::SkipURL(rule_str) => {
-                regex_for_robots(rule_str, WildcardType::Regex).expect("Invalid SkipURL regex")
-            }
-        }
-    }
-}
-
-/// Contexts are a set of domains/URLs/etc. that restricts a search space to
-/// improve results.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct LensConfig {
-    #[serde(default = "LensConfig::default_author")]
-    pub author: String,
-    pub name: String,
-    pub description: Option<String>,
-    pub domains: Vec<String>,
-    pub urls: Vec<String>,
-    pub version: String,
-    #[serde(default = "LensConfig::default_is_enabled")]
-    pub is_enabled: bool,
-    #[serde(default)]
-    pub rules: Vec<LensRule>,
-    #[serde(default)]
-    pub trigger: String,
-}
-
-impl LensConfig {
-    fn default_author() -> String {
-        "Unknown".to_string()
-    }
-
-    fn default_is_enabled() -> bool {
-        true
-    }
-
-    pub fn into_regexes(&self) -> Vec<String> {
-        let mut filters: Vec<String> = Vec::new();
-        for domain in &self.domains {
-            filters.push(regex_for_domain(domain));
-        }
-
-        for prefix in &self.urls {
-            filters.push(regex_for_prefix(prefix));
-        }
-
-        for rule in &self.rules {
-            filters.push(rule.to_regex());
-        }
-
-        filters
     }
 }
 

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -291,25 +291,3 @@ impl Config {
         config
     }
 }
-
-#[cfg(test)]
-mod test {
-    use super::LensConfig;
-
-    #[test]
-    fn test_into_regexes() {
-        let config = LensConfig {
-            domains: vec!["paulgraham.com".to_string()],
-            urls: vec!["https://oldschool.runescape.wiki/wiki/".to_string()],
-            ..Default::default()
-        };
-
-        let regexes = config.into_regexes();
-        dbg!(&regexes);
-        assert_eq!(regexes.len(), 2);
-        // Should contain domain regex
-        assert!(regexes.contains(&"^(http://|https://)paulgraham\\.com.*".to_string()));
-        // Should contain url prefix regex
-        assert!(regexes.contains(&"^https://oldschool.runescape.wiki/wiki/.*".to_string()));
-    }
-}

--- a/crates/spyglass-lens/Cargo.toml
+++ b/crates/spyglass-lens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyglass-lens"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
 description = "A small library for reading/writing spyglass lens files."

--- a/crates/spyglass-lens/Cargo.toml
+++ b/crates/spyglass-lens/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "spyglass-lens"
+version = "0.1.0"
+edition = "2021"
+authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
+description = "A small library for reading/writing spyglass lens files."
+homepage = "https://github.com/a5huynh/spyglass/tree/main/crates/spyglass-lens"
+repository = "https://github.com/a5huynh/spyglass/tree/main/crates/spyglass-lens"
+readme = "README.md"
+keywords = ["spyglass", "lens", "lenses"]
+license = "MIT"
+
+[dependencies]
+anyhow = "1.0"
+regex = "1"
+ron = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+
+[lib]
+name = "spyglass_lens"
+path = "src/lib.rs"
+crate-type = ["lib"]

--- a/crates/spyglass-lens/README.md
+++ b/crates/spyglass-lens/README.md
@@ -1,0 +1,3 @@
+## spyglass-lens
+
+A small library to manage/deal w/ spyglass lens files.

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 mod utils;
 use utils::{regex_for_domain, regex_for_prefix, regex_for_robots};
 
@@ -82,5 +82,27 @@ impl LensConfig {
             Ok(lens) => Ok(lens),
             Err(e) => Err(anyhow::Error::msg(e.to_string())),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LensConfig;
+
+    #[test]
+    fn test_into_regexes() {
+        let config = LensConfig {
+            domains: vec!["paulgraham.com".to_string()],
+            urls: vec!["https://oldschool.runescape.wiki/wiki/".to_string()],
+            ..Default::default()
+        };
+
+        let regexes = config.into_regexes();
+        dbg!(&regexes);
+        assert_eq!(regexes.len(), 2);
+        // Should contain domain regex
+        assert!(regexes.contains(&"^(http://|https://)paulgraham\\.com/.*".to_string()));
+        // Should contain url prefix regex
+        assert!(regexes.contains(&"^https://oldschool.runescape.wiki/wiki/.*".to_string()));
     }
 }

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 mod utils;
 use utils::{regex_for_domain, regex_for_prefix, regex_for_robots};
@@ -73,5 +74,13 @@ impl LensConfig {
         }
 
         filters
+    }
+
+    pub fn from_path(path: PathBuf) -> anyhow::Result<Self> {
+        let contents = std::fs::read_to_string(path)?;
+        match ron::from_str::<LensConfig>(&contents) {
+            Ok(lens) => Ok(lens),
+            Err(e) => Err(anyhow::Error::msg(e.to_string())),
+        }
     }
 }

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+mod utils;
+use utils::{regex_for_domain, regex_for_prefix, regex_for_robots};
+
+/// Different rules that filter out the URLs that would be crawled for a lens
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum LensRule {
+    /// Limits the depth of a URL to a certain depth.
+    /// For example:
+    ///  - LimitURLDepth("https://example.com/", 1) will limit it to https://example.com/<path 1>
+    ///  - LimitURLDepth("https://example.com/", 2) will limit it to https://example.com/<path 1>/<path 2>
+    ///  - etc.
+    LimitURLDepth(String, u8),
+    /// Skips are applied when bootstrapping & crawling
+    SkipURL(String),
+}
+
+impl LensRule {
+    pub fn to_regex(&self) -> String {
+        match &self {
+            LensRule::LimitURLDepth(prefix, max_depth) => {
+                let prefix = prefix.trim_end_matches('/');
+                let regex = format!("^{}/?(/[^/]+/?){{0, {}}}$", prefix, max_depth);
+                regex
+            }
+            LensRule::SkipURL(rule_str) => {
+                regex_for_robots(rule_str).expect("Invalid SkipURL regex")
+            }
+        }
+    }
+}
+
+/// Contexts are a set of domains/URLs/etc. that restricts a search space to
+/// improve results.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct LensConfig {
+    #[serde(default = "LensConfig::default_author")]
+    pub author: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub domains: Vec<String>,
+    pub urls: Vec<String>,
+    pub version: String,
+    #[serde(default = "LensConfig::default_is_enabled")]
+    pub is_enabled: bool,
+    #[serde(default)]
+    pub rules: Vec<LensRule>,
+    #[serde(default)]
+    pub trigger: String,
+}
+
+impl LensConfig {
+    fn default_author() -> String {
+        "Unknown".to_string()
+    }
+
+    fn default_is_enabled() -> bool {
+        true
+    }
+
+    pub fn into_regexes(&self) -> Vec<String> {
+        let mut filters: Vec<String> = Vec::new();
+        for domain in &self.domains {
+            filters.push(regex_for_domain(domain));
+        }
+
+        for prefix in &self.urls {
+            filters.push(regex_for_prefix(prefix));
+        }
+
+        for rule in &self.rules {
+            filters.push(rule.to_regex());
+        }
+
+        filters
+    }
+}

--- a/crates/spyglass-lens/src/utils.rs
+++ b/crates/spyglass-lens/src/utils.rs
@@ -1,0 +1,51 @@
+/// Convert a base domain string, e.g. "example.com" into a regex
+/// that can be used to match against URLs, e.g. "^(http://|https://)example.com.*"
+pub fn regex_for_domain(domain: &str) -> String {
+    let mut regex = String::new();
+    for ch in domain.chars() {
+        match ch {
+            '*' => regex.push_str(".*"),
+            _ => regex.push_str(&regex::escape(&ch.to_string())),
+        }
+    }
+
+    format!("^(http://|https://){}/.*", regex)
+}
+
+pub fn regex_for_prefix(prefix: &str) -> String {
+    if prefix.ends_with('$') {
+        return format!("^{}", prefix);
+    }
+
+    format!("^{}.*", prefix)
+}
+
+/// Convert a robots.txt rule into a proper regex string
+pub fn regex_for_robots(rule: &str) -> Option<String> {
+    if rule.is_empty() {
+        return None;
+    }
+
+    let wildcard = ".*";
+    let mut regex = String::new();
+    let mut has_end = false;
+    for ch in rule.chars() {
+        match ch {
+            '*' => regex.push_str(wildcard),
+            '^' => {
+                // Ignore carets when converting for database
+                regex.push('^');
+                has_end = true;
+            }
+            other_ch => {
+                regex.push_str(&regex::escape(&other_ch.to_string()));
+            }
+        }
+    }
+
+    if !has_end && !regex.ends_with(wildcard) {
+        regex.push_str(wildcard);
+    }
+
+    Some(regex)
+}

--- a/crates/spyglass-plugin/Cargo.toml
+++ b/crates/spyglass-plugin/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "spyglass-plugin"
 version = "0.1.0"
-edition = "2021"
+authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
 description = "A small client-side library for writing spyglass plugins"
+homepage = "https://github.com/a5huynh/spyglass/tree/main/crates/spyglass-plugin"
+repository = "https://github.com/a5huynh/spyglass/tree/main/crates/spyglass-plugin"
+readme = "README.md"
+keywords = ["spyglass", "webassembly", "wasm", "plugins"]
+edition = "2021"
 license = "MIT"
 
 [dependencies]

--- a/crates/spyglass-plugin/README.md
+++ b/crates/spyglass-plugin/README.md
@@ -1,0 +1,3 @@
+## spyglass-plugin
+
+A small client side library for writing spyglass plugins.


### PR DESCRIPTION
- Pulled out useful lens file related data structures into a publishable crate
- Published [`spyglass-plugin`](https://crates.io/crates/spyglass-plugin) (mostly a placeholder for now as we build this out) & [`spyglass-lens`](https://crates.io/crates/spyglass-lens) to crates.io
