### PR TITLE
tweak: take into account skip rules in lens/search filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "spyglass-lens"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "regex",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "spyglass-plugin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ron",
  "serde",

--- a/crates/spyglass-lens/Cargo.toml
+++ b/crates/spyglass-lens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyglass-lens"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
 description = "A small library for reading/writing spyglass lens files."

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -108,14 +108,17 @@ mod test {
             ..Default::default()
         };
 
-        let regexes = config.into_regexes().unwrap();
+        let regexes = config.into_regexes();
         assert_eq!(regexes.allowed.len(), 2);
-        assert!(regexes.skipped.is_none());
+        assert_eq!(regexes.skipped.len(), 0);
 
-        assert!(regexes.is_allowed("http://paulgraham.com"));
-        assert!(regexes.is_allowed("https://paulgraham.com"));
+        dbg!(&regexes.allowed);
 
-        assert!(regexes.is_allowed("https://oldschool.runescape.wiki/w/Test_Page"));
-        assert!(!regexes.is_allowed("https://oldschool.runescape.wiki/root"));
+        assert!(regexes
+            .allowed
+            .contains(&"^(http://|https://)paulgraham\\.com.*".to_string()));
+        assert!(regexes
+            .allowed
+            .contains(&"^https://oldschool.runescape.wiki/w/.*".to_string()));
     }
 }

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+
 mod utils;
 use utils::{regex_for_domain, regex_for_prefix, regex_for_robots};
 
@@ -31,6 +32,11 @@ impl LensRule {
     }
 }
 
+pub struct LensFilters {
+    pub allowed: Vec<String>,
+    pub skipped: Vec<String>,
+}
+
 /// Contexts are a set of domains/URLs/etc. that restricts a search space to
 /// improve results.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -59,21 +65,26 @@ impl LensConfig {
         true
     }
 
-    pub fn into_regexes(&self) -> Vec<String> {
-        let mut filters: Vec<String> = Vec::new();
+    pub fn into_regexes(&self) -> LensFilters {
+        let mut allowed = Vec::new();
+        let mut skipped = Vec::new();
+
         for domain in &self.domains {
-            filters.push(regex_for_domain(domain));
+            allowed.push(regex_for_domain(domain));
         }
 
         for prefix in &self.urls {
-            filters.push(regex_for_prefix(prefix));
+            allowed.push(regex_for_prefix(prefix));
         }
 
         for rule in &self.rules {
-            filters.push(rule.to_regex());
+            match rule {
+                LensRule::LimitURLDepth { .. } => allowed.push(rule.to_regex()),
+                LensRule::SkipURL(_) => skipped.push(rule.to_regex()),
+            }
         }
 
-        filters
+        LensFilters { allowed, skipped }
     }
 
     pub fn from_path(path: PathBuf) -> anyhow::Result<Self> {
@@ -93,16 +104,18 @@ mod test {
     fn test_into_regexes() {
         let config = LensConfig {
             domains: vec!["paulgraham.com".to_string()],
-            urls: vec!["https://oldschool.runescape.wiki/wiki/".to_string()],
+            urls: vec!["https://oldschool.runescape.wiki/w/".to_string()],
             ..Default::default()
         };
 
-        let regexes = config.into_regexes();
-        dbg!(&regexes);
-        assert_eq!(regexes.len(), 2);
-        // Should contain domain regex
-        assert!(regexes.contains(&"^(http://|https://)paulgraham\\.com/.*".to_string()));
-        // Should contain url prefix regex
-        assert!(regexes.contains(&"^https://oldschool.runescape.wiki/wiki/.*".to_string()));
+        let regexes = config.into_regexes().unwrap();
+        assert_eq!(regexes.allowed.len(), 2);
+        assert!(regexes.skipped.is_none());
+
+        assert!(regexes.is_allowed("http://paulgraham.com"));
+        assert!(regexes.is_allowed("https://paulgraham.com"));
+
+        assert!(regexes.is_allowed("https://oldschool.runescape.wiki/w/Test_Page"));
+        assert!(!regexes.is_allowed("https://oldschool.runescape.wiki/root"));
     }
 }

--- a/crates/spyglass-lens/src/utils.rs
+++ b/crates/spyglass-lens/src/utils.rs
@@ -9,7 +9,7 @@ pub fn regex_for_domain(domain: &str) -> String {
         }
     }
 
-    format!("^(http://|https://){}/.*", regex)
+    format!("^(http://|https://){}.*", regex)
 }
 
 pub fn regex_for_prefix(prefix: &str) -> String {

--- a/crates/spyglass-plugin/Cargo.toml
+++ b/crates/spyglass-plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyglass-plugin"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
 description = "A small client-side library for writing spyglass plugins"
 homepage = "https://github.com/a5huynh/spyglass/tree/main/crates/spyglass-plugin"

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -1,15 +1,15 @@
 pub mod consts;
 mod shims;
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
 pub use shims::*;
+use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SearchFilter {
     // No filter
     None,
-    URLRegex(String),
+    URLRegexAllow(String),
+    URLRegexSkip(String),
 }
 
 #[macro_export]

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -311,7 +311,7 @@ mod test {
         assert_eq!(filters.len(), 1);
         assert_eq!(
             *filters.get(0).unwrap(),
-            SearchFilter::URLRegex("^https://oldschool.runescape.wiki/wiki/.*".to_owned())
+            SearchFilter::URLRegexAllow("^https://oldschool.runescape.wiki/wiki/.*".to_owned())
         );
     }
 }

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -225,11 +225,20 @@ pub async fn lens_to_filters(state: AppState, trigger: &str) -> Vec<SearchFilter
             // Load lens configuration from files
             lens::LensType::Simple => {
                 if let Some(lens_config) = state.lenses.get(&lens.name) {
+                    let lens_filters = lens_config.into_regexes();
                     filters.extend(
-                        lens_config
-                            .into_regexes()
+                        lens_filters
+                            .allowed
                             .into_iter()
-                            .map(SearchFilter::URLRegex)
+                            .map(SearchFilter::URLRegexAllow)
+                            .collect::<Vec<SearchFilter>>(),
+                    );
+
+                    filters.extend(
+                        lens_filters
+                            .skipped
+                            .into_iter()
+                            .map(SearchFilter::URLRegexSkip)
                             .collect::<Vec<SearchFilter>>(),
                     );
                 }

--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -332,8 +332,9 @@ mod test {
 
         let applied_lens = lens
             .into_regexes()
+            .allowed
             .into_iter()
-            .map(SearchFilter::URLRegex)
+            .map(SearchFilter::URLRegexAllow)
             .collect();
         let mut searcher = Searcher::with_index(&IndexPath::Memory);
         _build_test_index(&mut searcher);
@@ -356,8 +357,9 @@ mod test {
 
         let applied_lens = lens
             .into_regexes()
+            .allowed
             .into_iter()
-            .map(SearchFilter::URLRegex)
+            .map(SearchFilter::URLRegexAllow)
             .collect();
         let mut searcher = Searcher::with_index(&IndexPath::Memory);
         _build_test_index(&mut searcher);
@@ -380,8 +382,9 @@ mod test {
 
         let applied_lens = lens
             .into_regexes()
+            .allowed
             .into_iter()
-            .map(SearchFilter::URLRegex)
+            .map(SearchFilter::URLRegexAllow)
             .collect();
 
         let mut searcher = Searcher::with_index(&IndexPath::Memory);

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -114,6 +114,6 @@ impl SpyglassPlugin for Plugin {
     }
 
     fn search_filter(&mut self) -> Vec<SearchFilter> {
-        vec![SearchFilter::URLRegex("file://.*".to_string())]
+        vec![SearchFilter::URLRegexAllow("file://.*".to_string())]
     }
 }


### PR DESCRIPTION
- Split filters into allowed / skipped, adds support for filtering search results w/ `LensRule::SkipURL`