### PR TITLE
feature: update rpc backend & prepping for headless server support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +423,15 @@ name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -509,9 +533,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cache-padded"
@@ -1120,11 +1144,20 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.2",
  "crypto-common",
  "subtle",
 ]
@@ -1586,6 +1619,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,7 +1851,7 @@ checksum = "25a68131a662b04931e71891fb14aaf65ee4b44d08e8abc10f49e77418c86c64"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2084,7 +2127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f518afe90c23fba585b2d7697856f9e6a7bbc62f65588035e66f6afb01a2e9"
 dependencies = [
  "anyhow",
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2185,7 +2228,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2281,6 +2324,22 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
+dependencies = [
+ "http",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2575,33 +2634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-derive"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
-dependencies = [
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jsonrpc-ipc-server"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382bb0206323ca7cda3dcd7e245cea86d37d02457a02a975e3378fb149a48845"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-server-utils",
- "log",
- "parity-tokio-ipc",
- "parking_lot 0.11.2",
- "tower-service",
-]
-
-[[package]]
 name = "jsonrpc-pubsub"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2664,189 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.6.10",
  "unicase",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-http-server",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "jsonrpsee-ws-server",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8752740ecd374bcbf8b69f3e80b0327942df76f793f8d4e60d3355650c31fb74"
+dependencies = [
+ "anyhow",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustls-native-certs",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util 0.7.3",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
+dependencies = [
+ "anyhow",
+ "arrayvec 0.7.2",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-channel",
+ "futures-timer",
+ "futures-util",
+ "globset",
+ "http",
+ "hyper",
+ "jsonrpsee-types",
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "unicase",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f7c0e2333ab2115c302eeb4f137c8a4af5ab609762df68bbda8f06496677c9"
+dependencies = [
+ "async-trait",
+ "hyper",
+ "hyper-rustls",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd67957d4280217247588ac86614ead007b301ca2fa9f19c19f880a536f029e3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597b4eb94730e7695d0a2a429bc37a12e6e84d12680fdafb9b8f5f53652aab57"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee5feddd5188e62ac08fcf0e56478138e581509d4730f3f7be9b57dd402a4ff"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-server"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d488ba74fb369e5ab68926feb75a483458b88e768d44319f37e4ecad283c7325"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.3",
+ "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -2921,7 +3136,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
 dependencies = [
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -3127,7 +3342,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.4.12",
  "itoa 0.4.8",
 ]
 
@@ -3197,7 +3412,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -3286,6 +3501,12 @@ checksum = "f3b8d98df258e762e901eb4349d66d5a5f5a7a994db8df82ff596011773be535"
 dependencies = [
  "loom",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
@@ -3791,15 +4012,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
-]
-
-[[package]]
-name = "proc-macro-crate"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
@@ -4294,6 +4506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4609,6 +4833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "sentry"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +5048,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,7 +5083,7 @@ checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -4858,9 +5101,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories",
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
+ "jsonrpsee",
  "log",
  "regex",
  "ron",
@@ -4923,6 +5164,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures 0.3.21",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
+]
+
+[[package]]
 name = "soup2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,9 +5227,10 @@ version = "22.9.1"
 dependencies = [
  "addr",
  "anyhow",
+ "bytes",
  "chrono",
  "dashmap",
- "digest",
+ "digest 0.10.3",
  "directories",
  "dirs",
  "ego-tree",
@@ -4983,9 +5240,7 @@ dependencies = [
  "hostname",
  "html5ever",
  "http",
- "hyper",
- "jsonrpc-core",
- "jsonrpc-ipc-server",
+ "jsonrpsee",
  "log",
  "migration",
  "notify",
@@ -5961,6 +6216,7 @@ checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6025,6 +6281,16 @@ checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "url 2.2.2",
+ "url",
  "wildmatch",
 ]
 
@@ -1305,7 +1305,7 @@ dependencies = [
  "shared",
  "tantivy",
  "tokio",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -1482,7 +1482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1513,12 +1513,6 @@ dependencies = [
  "mac",
  "new_debug_unreachable",
 ]
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -1560,7 +1554,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1634,7 +1627,6 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -2149,7 +2141,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2373,17 +2365,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
@@ -2590,83 +2571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-client-transports"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
-dependencies = [
- "derive_more",
- "futures 0.3.21",
- "jsonrpc-core",
- "jsonrpc-pubsub",
- "jsonrpc-server-utils",
- "log",
- "parity-tokio-ipc",
- "serde",
- "serde_json",
- "tokio",
- "url 1.7.2",
-]
-
-[[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures 0.3.21",
- "futures-executor",
- "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "jsonrpc-core-client"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-client-transports",
-]
-
-[[package]]
-name = "jsonrpc-pubsub"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
-dependencies = [
- "futures 0.3.21",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "parking_lot 0.11.2",
- "rand 0.7.3",
- "serde",
-]
-
-[[package]]
-name = "jsonrpc-server-utils"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
-dependencies = [
- "bytes",
- "futures 0.3.21",
- "globset",
- "jsonrpc-core",
- "lazy_static",
- "log",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "unicase",
-]
-
-[[package]]
 name = "jsonrpsee"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,7 +2608,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
  "webpki-roots",
 ]
@@ -2844,7 +2748,7 @@ dependencies = [
  "soketto",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
@@ -2984,7 +2888,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spyglass-plugin",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -3668,20 +3572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-tokio-ipc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9981e32fb75e004cc148f5fb70342f393830e0a4aa62e3cc93b50976218d42b6"
-dependencies = [
- "futures 0.3.21",
- "libc",
- "log",
- "rand 0.7.3",
- "tokio",
- "winapi",
-]
-
-[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,12 +3636,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -4332,7 +4216,7 @@ dependencies = [
  "log",
  "mime",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -4340,7 +4224,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4600,7 +4484,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
- "futures 0.3.21",
+ "futures",
  "futures-util",
  "log",
  "once_cell",
@@ -4611,7 +4495,7 @@ dependencies = [
  "serde",
  "sqlx",
  "tracing",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -4628,7 +4512,7 @@ dependencies = [
  "sea-schema",
  "tracing",
  "tracing-subscriber",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -4702,7 +4586,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d070aba647637b533bd669a8e430bdc8f7d5249c9b53402da34347563bbfca"
 dependencies = [
- "futures 0.3.21",
+ "futures",
  "sea-query",
  "sea-schema-derive",
 ]
@@ -4914,7 +4798,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time 0.3.11",
- "url 2.2.2",
+ "url",
  "uuid 1.1.2",
 ]
 
@@ -5110,7 +4994,7 @@ dependencies = [
  "spyglass-lens",
  "strum 0.24.1",
  "strum_macros 0.24.2",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -5171,7 +5055,7 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64",
  "bytes",
- "futures 0.3.21",
+ "futures",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -5235,7 +5119,7 @@ dependencies = [
  "dirs",
  "ego-tree",
  "entities",
- "futures 0.3.21",
+ "futures",
  "hex",
  "hostname",
  "html5ever",
@@ -5261,7 +5145,7 @@ dependencies = [
  "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
- "url 2.2.2",
+ "url",
  "uuid 1.1.2",
  "wasmer",
  "wasmer-wasi",
@@ -5274,8 +5158,7 @@ dependencies = [
  "anyhow",
  "auto-launch",
  "cocoa",
- "jsonrpc-core",
- "jsonrpc-core-client",
+ "jsonrpsee",
  "log",
  "migration",
  "num-format",
@@ -5296,7 +5179,7 @@ dependencies = [
  "tracing-appender",
  "tracing-log",
  "tracing-subscriber",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -5312,7 +5195,7 @@ dependencies = [
  "shared",
  "strum 0.24.1",
  "strum_macros 0.24.2",
- "url 2.2.2",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-logger",
@@ -5392,7 +5275,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "paste",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rustls",
  "rustls-pemfile",
  "sha2",
@@ -5402,7 +5285,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tokio-stream",
- "url 2.2.2",
+ "url",
  "webpki-roots",
 ]
 
@@ -5422,7 +5305,7 @@ dependencies = [
  "sqlx-core",
  "sqlx-rt",
  "syn",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
@@ -5801,7 +5684,7 @@ dependencies = [
  "dirs-next",
  "embed_plist",
  "flate2",
- "futures 0.3.21",
+ "futures",
  "futures-lite",
  "glib",
  "glob",
@@ -5816,7 +5699,7 @@ dependencies = [
  "open 3.0.2",
  "os_info",
  "os_pipe",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
  "regex",
@@ -5837,7 +5720,7 @@ dependencies = [
  "thiserror",
  "time 0.3.11",
  "tokio",
- "url 2.2.2",
+ "url",
  "uuid 1.1.2",
  "webkit2gtk",
  "webview2-com",
@@ -5929,7 +5812,7 @@ checksum = "3fa8c4edaf01d8b556e7172c844b1b4dd3399adcd1a606bd520fc3e65f698546"
 dependencies = [
  "cocoa",
  "gtk",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "rand 0.8.5",
  "raw-window-handle",
  "tauri-runtime",
@@ -5963,7 +5846,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror",
- "url 2.2.2",
+ "url",
  "walkdir",
  "windows 0.37.0",
 ]
@@ -6196,20 +6079,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
@@ -6414,25 +6283,14 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
 ]
 
@@ -7420,7 +7278,7 @@ dependencies = [
  "serde_json",
  "tao",
  "thiserror",
- "url 2.2.2",
+ "url",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4985,7 +4985,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "directories",
- "jsonrpsee",
  "log",
  "regex",
  "ron",
@@ -5137,6 +5136,7 @@ dependencies = [
  "sha2",
  "shared",
  "spyglass-plugin",
+ "spyglass-rpc",
  "tantivy",
  "tendril",
  "tokio",
@@ -5169,6 +5169,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
+ "spyglass-rpc",
  "strum 0.24.1",
  "strum_macros 0.24.2",
  "tauri",
@@ -5220,6 +5221,14 @@ version = "0.1.1"
 dependencies = [
  "ron",
  "serde",
+]
+
+[[package]]
+name = "spyglass-rpc"
+version = "0.1.0"
+dependencies = [
+ "jsonrpsee",
+ "shared",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4983,6 +4983,7 @@ dependencies = [
  "hostname",
  "html5ever",
  "http",
+ "hyper",
  "jsonrpc-core",
  "jsonrpc-ipc-server",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     # Publically published crates
     "crates/spyglass-plugin",
     "crates/spyglass-lens",
+    "crates/spyglass-rpc",
     # Default plugins
     "plugins/chrome-importer",
     "plugins/firefox-importer",

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -8,9 +8,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 directories = "4.0"
-jsonrpc-core = "18.0.0"
-jsonrpc-core-client = "18.0.0"
-jsonrpc-derive = "18.0.0"
+# We only need the macros functionality for the shared library
+jsonrpsee = { version = "0.15", features = ["macros"] }
 log = "0.4"
 regex = "1"
 ron = "0.8"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 directories = "4.0"
-# We only need the macros functionality for the shared library
-jsonrpsee = { version = "0.15", features = ["macros"] }
 log = "0.4"
 regex = "1"
 ron = "0.8"

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -78,6 +78,8 @@ pub struct UserSettings {
     pub plugin_settings: PluginSettings,
     #[serde(default)]
     pub disable_autolaunch: bool,
+    #[serde(default = "UserSettings::default_port")]
+    pub port: u16,
 }
 
 impl UserSettings {
@@ -87,6 +89,10 @@ impl UserSettings {
 
     fn default_shortcut() -> String {
         "CmdOrCtrl+Shift+/".to_string()
+    }
+
+    fn default_port() -> u16 {
+        4664
     }
 
     pub fn constraint_limits(&mut self) {
@@ -142,6 +148,7 @@ impl Default for UserSettings {
             disable_telementry: false,
             plugin_settings: Default::default(),
             disable_autolaunch: false,
+            port: UserSettings::default_port(),
         }
     }
 }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,6 @@ pub mod plugin;
 pub mod regex;
 pub mod request;
 pub mod response;
-pub mod rpc;
 
 /// A platform-agnostic way to turn a URL file path into something that can
 /// be opened & crawled.

--- a/crates/shared/src/rpc.rs
+++ b/crates/shared/src/rpc.rs
@@ -1,5 +1,5 @@
-use jsonrpc_core::{BoxFuture, Result};
-use jsonrpc_derive::rpc;
+use jsonrpsee::core::Error;
+use jsonrpsee::proc_macros::rpc;
 
 use crate::request::{SearchLensesParam, SearchParam};
 use crate::response::{
@@ -15,42 +15,42 @@ pub fn gen_ipc_path() -> String {
 }
 
 /// Rpc trait
-#[rpc]
+#[rpc(server, client, namespace = "state")]
 pub trait Rpc {
     /// Returns a protocol version
-    #[rpc(name = "protocol_version")]
-    fn protocol_version(&self) -> Result<String>;
+    #[method(name = "protocol_version")]
+    fn protocol_version(&self) -> Result<String, Error>;
 
-    #[rpc(name = "app_status")]
-    fn app_status(&self) -> BoxFuture<Result<AppStatus>>;
+    #[method(name = "app_status")]
+    async fn app_status(&self) -> Result<AppStatus, Error>;
 
-    #[rpc(name = "crawl_stats")]
-    fn crawl_stats(&self) -> BoxFuture<Result<CrawlStats>>;
+    #[method(name = "crawl_stats")]
+    async fn crawl_stats(&self) -> Result<CrawlStats, Error>;
 
-    #[rpc(name = "delete_doc")]
-    fn delete_doc(&self, id: String) -> BoxFuture<Result<()>>;
+    #[method(name = "delete_doc")]
+    async fn delete_doc(&self, id: String) -> Result<(), Error>;
 
-    #[rpc(name = "delete_domain")]
-    fn delete_domain(&self, domain: String) -> BoxFuture<Result<()>>;
+    #[method(name = "delete_domain")]
+    async fn delete_domain(&self, domain: String) -> Result<(), Error>;
 
-    #[rpc(name = "list_installed_lenses")]
-    fn list_installed_lenses(&self) -> BoxFuture<Result<Vec<LensResult>>>;
+    #[method(name = "list_installed_lenses")]
+    async fn list_installed_lenses(&self) -> Result<Vec<LensResult>, Error>;
 
-    #[rpc(name = "list_plugins")]
-    fn list_plugins(&self) -> BoxFuture<Result<Vec<PluginResult>>>;
+    #[method(name = "list_plugins")]
+    async fn list_plugins(&self) -> Result<Vec<PluginResult>, Error>;
 
-    #[rpc(name = "recrawl_domain")]
-    fn recrawl_domain(&self, domain: String) -> BoxFuture<Result<()>>;
+    #[method(name = "recrawl_domain")]
+    async fn recrawl_domain(&self, domain: String) -> Result<(), Error>;
 
-    #[rpc(name = "search_docs")]
-    fn search_docs(&self, query: SearchParam) -> BoxFuture<Result<SearchResults>>;
+    #[method(name = "search_docs")]
+    async fn search_docs(&self, query: SearchParam) -> Result<SearchResults, Error>;
 
-    #[rpc(name = "search_lenses")]
-    fn search_lenses(&self, query: SearchLensesParam) -> BoxFuture<Result<SearchLensesResp>>;
+    #[method(name = "search_lenses")]
+    async fn search_lenses(&self, query: SearchLensesParam) -> Result<SearchLensesResp, Error>;
 
-    #[rpc(name = "toggle_pause")]
-    fn toggle_pause(&self, is_paused: bool) -> BoxFuture<Result<()>>;
+    #[method(name = "toggle_pause")]
+    async fn toggle_pause(&self, is_paused: bool) -> Result<(), Error>;
 
-    #[rpc(name = "toggle_plugin")]
-    fn toggle_plugin(&self, name: String) -> BoxFuture<Result<()>>;
+    #[method(name = "toggle_plugin")]
+    async fn toggle_plugin(&self, name: String) -> Result<(), Error>;
 }

--- a/crates/spyglass-rpc/Cargo.toml
+++ b/crates/spyglass-rpc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spyglass-rpc"
+version = "0.1.0"
+authors = ["Andrew Huynh <andrew@spyglass.fyi>"]
+description = "RPC definitions for spyglass server"
+edition = "2021"
+
+[dependencies]
+# We only need the macros functionality for the shared library
+jsonrpsee = { version = "0.15", features = ["macros"] }
+shared = { path = "../shared" }
+
+[lib]
+name = "spyglass_rpc"
+path = "src/lib.rs"
+crate-type = ["lib"]

--- a/crates/spyglass-rpc/src/lib.rs
+++ b/crates/spyglass-rpc/src/lib.rs
@@ -1,18 +1,10 @@
 use jsonrpsee::core::Error;
 use jsonrpsee::proc_macros::rpc;
 
-use crate::request::{SearchLensesParam, SearchParam};
-use crate::response::{
+use shared::request::{SearchLensesParam, SearchParam};
+use shared::response::{
     AppStatus, CrawlStats, LensResult, PluginResult, SearchLensesResp, SearchResults,
 };
-
-pub fn gen_ipc_path() -> String {
-    if cfg!(windows) {
-        r"\\.\pipe\ipc-spyglass".to_string()
-    } else {
-        r"/tmp/ipc-spyglass".to_string()
-    }
-}
 
 /// Rpc trait
 #[rpc(server, client, namespace = "state")]

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -18,6 +18,7 @@ hex = "0.4"
 hostname = "^0.3"
 html5ever = "0.25"
 http = "0.2"
+hyper = { version = "0.14", features = ["full"] }
 jsonrpc-core = "18.0.0"
 jsonrpc-ipc-server = "18.0.0"
 log = "0.4"

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4"
 hostname = "^0.3"
 html5ever = "0.25"
 http = "0.2"
-jsonrpsee = { version = "0.15", features = ["full"] }
+jsonrpsee = { version = "0.15", features = ["http-server"] }
 log = "0.4"
 migration = { path = "../migrations" }
 notify = "5.0.0-pre.16"
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 shared = { path = "../shared" }
 spyglass-plugin = { path = "../spyglass-plugin" }
+spyglass-rpc = { path = "../spyglass-rpc" }
 tantivy = "0.18"
 tendril = "0.4.2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 addr = "0.15.3"
 anyhow = "1.0"
+bytes = "1.2.1"
 chrono = { version = "0.4", features = ["serde"] }
 dashmap = "5.2"
 digest = "0.10"
@@ -18,9 +19,7 @@ hex = "0.4"
 hostname = "^0.3"
 html5ever = "0.25"
 http = "0.2"
-hyper = { version = "0.14", features = ["full"] }
-jsonrpc-core = "18.0.0"
-jsonrpc-ipc-server = "18.0.0"
+jsonrpsee = { version = "0.15", features = ["full"] }
 log = "0.4"
 migration = { path = "../migrations" }
 notify = "5.0.0-pre.16"

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -1,6 +1,6 @@
 use jsonrpsee::core::{async_trait, Error};
 use libspyglass::state::AppState;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 
@@ -67,9 +67,8 @@ impl RpcServer for SpyglassRpc {
 }
 
 pub async fn start_api_server(state: AppState) -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
-    let server = HttpServerBuilder::default()
-        .build("127.0.0.1:1234".parse::<SocketAddr>()?)
-        .await?;
+    let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), state.user_settings.port);
+    let server = HttpServerBuilder::default().build(server_addr).await?;
 
     let rpc_module = SpyglassRpc {
         state: state.clone(),

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -6,7 +6,7 @@ use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
 
 use shared::request::{SearchLensesParam, SearchParam};
 use shared::response::{AppStatus, CrawlStats, LensResult, SearchLensesResp, SearchResults};
-use shared::rpc::RpcServer;
+use spyglass_rpc::RpcServer;
 
 mod response;
 mod route;
@@ -68,7 +68,7 @@ impl RpcServer for SpyglassRpc {
 
 pub async fn start_api_server(state: AppState) -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
     let server = HttpServerBuilder::default()
-        .build("127.0.0.1:0".parse::<SocketAddr>()?)
+        .build("127.0.0.1:1234".parse::<SocketAddr>()?)
         .await?;
 
     let rpc_module = SpyglassRpc {

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -18,6 +18,7 @@ use tokio::sync::{broadcast, mpsc};
 // The pipeline context is a context object that is passed between
 // all stages of the pipeline. This allows later stages in the pipeline
 // to change behavior based on previous stages.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct PipelineContext {
     pipeline_name: String,

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -28,6 +28,7 @@ sentry = "0.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shared = { path = "../shared" }
+spyglass-rpc = { path = "../spyglass-rpc" }
 strum = "0.24"
 strum_macros = "0.24"
 tauri = { version = "1.0.5", features = ["api-all", "devtools", "dialog", "notification", "process-command-api", "system-tray", "updater"] }

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -17,8 +17,7 @@ tauri-build = { version = "1.0.0", features = [] }
 [dependencies]
 anyhow = "1.0"
 auto-launch = "0.2.0"
-jsonrpc-core = "18.0.0"
-jsonrpc-core-client = { version = "18.0.0", features = ["ipc"] }
+jsonrpsee = { version = "0.15", features = ["full"] }
 log = "0.4"
 migration = { path = "../migrations" }
 num-format = "0.4"

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -1,4 +1,3 @@
-use shared::rpc::RpcClient;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -18,6 +17,7 @@ use shared::{
     request,
     response::{self, InstallableLens},
 };
+use spyglass_rpc::RpcClient;
 
 #[tauri::command]
 pub async fn escape(window: tauri::Window) -> Result<(), String> {

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -77,12 +77,11 @@ pub async fn crawl_stats<'r>(
     _: tauri::Window,
     rpc: State<'_, rpc::RpcMutex>,
 ) -> Result<response::CrawlStats, String> {
-    let mut rpc = rpc.lock().await;
+    let rpc = rpc.lock().await;
     match rpc.client.crawl_stats().await {
         Ok(resp) => Ok(resp),
         Err(err) => {
             log::error!("Error sending RPC: {}", err);
-            rpc.reconnect().await;
             Ok(response::CrawlStats {
                 by_domain: Vec::new(),
             })

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -73,34 +73,40 @@ pub async fn resize_window(window: tauri::Window, height: f64) {
 }
 
 #[tauri::command]
-pub async fn crawl_stats<'r>(
-    _: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-) -> Result<response::CrawlStats, String> {
-    let rpc = rpc.lock().await;
-    match rpc.client.crawl_stats().await {
-        Ok(resp) => Ok(resp),
-        Err(err) => {
-            log::error!("Error sending RPC: {}", err);
-            Ok(response::CrawlStats {
-                by_domain: Vec::new(),
-            })
+pub async fn crawl_stats<'r>(win: tauri::Window) -> Result<response::CrawlStats, String> {
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        match rpc.client.crawl_stats().await {
+            Ok(resp) => Ok(resp),
+            Err(err) => {
+                log::error!("Error sending RPC: {}", err);
+                Ok(response::CrawlStats {
+                    by_domain: Vec::new(),
+                })
+            }
         }
+    } else {
+        Ok(response::CrawlStats {
+            by_domain: Vec::new(),
+        })
     }
 }
 
 #[tauri::command]
 pub async fn list_installed_lenses(
-    _: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
+    win: tauri::Window,
 ) -> Result<Vec<response::LensResult>, String> {
-    let rpc = rpc.lock().await;
-    match rpc.client.list_installed_lenses().await {
-        Ok(lenses) => Ok(lenses),
-        Err(err) => {
-            log::error!("Unable to list installed lenses: {}", err.to_string());
-            Ok(Vec::new())
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        match rpc.client.list_installed_lenses().await {
+            Ok(lenses) => Ok(lenses),
+            Err(err) => {
+                log::error!("Unable to list installed lenses: {}", err.to_string());
+                Ok(Vec::new())
+            }
         }
+    } else {
+        Ok(Vec::new())
     }
 }
 
@@ -127,59 +133,63 @@ pub async fn list_installable_lenses(
 
 #[tauri::command]
 pub async fn search_docs<'r>(
-    _: tauri::Window,
-    rpc: State<'r, rpc::RpcMutex>,
+    win: tauri::Window,
     lenses: Vec<String>,
     query: &str,
 ) -> Result<Vec<response::SearchResult>, String> {
-    let data = request::SearchParam {
-        lenses,
-        query: query.to_string(),
-    };
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let data = request::SearchParam {
+            lenses,
+            query: query.to_string(),
+        };
 
-    let rpc = rpc.lock().await;
-    match rpc.client.search_docs(data).await {
-        Ok(resp) => Ok(resp.results.to_vec()),
-        Err(err) => {
-            log::error!("search_docs err: {}", err);
-            Ok(Vec::new())
+        let rpc = rpc.lock().await;
+        match rpc.client.search_docs(data).await {
+            Ok(resp) => Ok(resp.results.to_vec()),
+            Err(err) => {
+                log::error!("search_docs err: {}", err);
+                Ok(Vec::new())
+            }
         }
+    } else {
+        Ok(Vec::new())
     }
 }
 
 #[tauri::command]
 pub async fn search_lenses<'r>(
-    _: tauri::Window,
-    rpc: State<'r, rpc::RpcMutex>,
+    win: tauri::Window,
     query: &str,
 ) -> Result<Vec<response::LensResult>, String> {
-    let data = request::SearchLensesParam {
-        query: query.to_string(),
-    };
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let data = request::SearchLensesParam {
+            query: query.to_string(),
+        };
 
-    let rpc = rpc.lock().await;
-    match rpc.client.search_lenses(data).await {
-        Ok(resp) => Ok(resp.results),
-        Err(err) => {
-            log::error!("search_lenses err: {}", err.to_string());
-            Ok(Vec::new())
+        let rpc = rpc.lock().await;
+        match rpc.client.search_lenses(data).await {
+            Ok(resp) => Ok(resp.results),
+            Err(err) => {
+                log::error!("search_lenses err: {}", err.to_string());
+                Ok(Vec::new())
+            }
         }
+    } else {
+        Ok(Vec::new())
     }
 }
 
 #[tauri::command]
-pub async fn delete_doc<'r>(
-    window: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-    id: &str,
-) -> Result<(), String> {
-    let rpc = rpc.lock().await;
-    match rpc.client.delete_doc(id.to_string()).await {
-        Ok(_) => {
-            let _ = window.emit(ClientEvent::RefreshSearchResults.as_ref(), true);
-        }
-        Err(err) => {
-            log::error!("delete_doc err: {}", err);
+pub async fn delete_doc<'r>(window: tauri::Window, id: &str) -> Result<(), String> {
+    if let Some(rpc) = window.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        match rpc.client.delete_doc(id.to_string()).await {
+            Ok(_) => {
+                let _ = window.emit(ClientEvent::RefreshSearchResults.as_ref(), true);
+            }
+            Err(err) => {
+                log::error!("delete_doc err: {}", err);
+            }
         }
     }
 
@@ -187,18 +197,16 @@ pub async fn delete_doc<'r>(
 }
 
 #[tauri::command]
-pub async fn delete_domain<'r>(
-    window: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-    domain: &str,
-) -> Result<(), String> {
-    let rpc = rpc.lock().await;
-    match rpc.client.delete_domain(domain.to_string()).await {
-        Ok(_) => {
-            let _ = window.emit(ClientEvent::RefreshSearchResults.as_ref(), true);
-        }
-        Err(err) => {
-            log::error!("delete_domain err: {}", err);
+pub async fn delete_domain<'r>(window: tauri::Window, domain: &str) -> Result<(), String> {
+    if let Some(rpc) = window.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        match rpc.client.delete_domain(domain.to_string()).await {
+            Ok(_) => {
+                let _ = window.emit(ClientEvent::RefreshSearchResults.as_ref(), true);
+            }
+            Err(err) => {
+                log::error!("delete_domain err: {}", err);
+            }
         }
     }
 
@@ -249,8 +257,7 @@ pub async fn install_lens<'r>(
 
 #[tauri::command]
 pub async fn network_change(
-    _: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
+    win: tauri::Window,
     paused: State<'_, Arc<PauseState>>,
     is_offline: bool,
 ) -> Result<(), String> {
@@ -260,53 +267,52 @@ pub async fn network_change(
     );
 
     if is_offline {
-        let rpc = rpc.lock().await;
-        paused.store(true, Ordering::Relaxed);
-        let _ = rpc.client.toggle_pause(true).await;
-    }
-
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn recrawl_domain(
-    _: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-    domain: &str,
-) -> Result<(), String> {
-    log::info!("recrawling {}", domain);
-    let rpc = rpc.lock().await;
-    if let Err(err) = rpc.client.recrawl_domain(domain.to_string()).await {
-        log::error!("recrawl_domain err: {}", err);
-    }
-
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn list_plugins(
-    _: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-) -> Result<Vec<response::PluginResult>, String> {
-    let rpc = rpc.lock().await;
-    match rpc.client.list_plugins().await {
-        Ok(plugins) => Ok(plugins),
-        Err(err) => {
-            log::error!("list_plugins err: {}", err.to_string());
-            Ok(Vec::new())
+        if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+            let rpc = rpc.lock().await;
+            paused.store(true, Ordering::Relaxed);
+            let _ = rpc.client.toggle_pause(true).await;
         }
     }
+
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn toggle_plugin(
-    window: tauri::Window,
-    rpc: State<'_, rpc::RpcMutex>,
-    name: &str,
-) -> Result<(), String> {
-    let rpc = rpc.lock().await;
-    let _ = rpc.client.toggle_plugin(name.to_string()).await;
-    let _ = window.emit(ClientEvent::RefreshPluginManager.as_ref(), true);
+pub async fn recrawl_domain(win: tauri::Window, domain: &str) -> Result<(), String> {
+    log::info!("recrawling {}", domain);
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        if let Err(err) = rpc.client.recrawl_domain(domain.to_string()).await {
+            log::error!("recrawl_domain err: {}", err);
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn list_plugins(win: tauri::Window) -> Result<Vec<response::PluginResult>, String> {
+    if let Some(rpc) = win.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        match rpc.client.list_plugins().await {
+            Ok(plugins) => Ok(plugins),
+            Err(err) => {
+                log::error!("list_plugins err: {}", err.to_string());
+                Ok(Vec::new())
+            }
+        }
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+#[tauri::command]
+pub async fn toggle_plugin(window: tauri::Window, name: &str) -> Result<(), String> {
+    if let Some(rpc) = window.app_handle().try_state::<rpc::RpcMutex>() {
+        let rpc = rpc.lock().await;
+        let _ = rpc.client.toggle_plugin(name.to_string()).await;
+        let _ = window.emit(ClientEvent::RefreshPluginManager.as_ref(), true);
+    }
 
     Ok(())
 }

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -23,6 +23,7 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 use cocoa::appkit::NSWindow;
 
 use shared::config::Config;
+use shared::rpc::RpcClient;
 
 mod cmd;
 mod constants;
@@ -258,7 +259,7 @@ async fn pause_crawler(app: AppHandle, menu_id: String) {
 
     match rpc
         .client
-        .call_method::<(bool,), ()>("toggle_pause", "", (!is_paused.load(Ordering::Relaxed),))
+        .toggle_pause(!is_paused.load(Ordering::Relaxed))
         .await
     {
         Ok(_) => {

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -254,7 +254,7 @@ async fn pause_crawler(app: AppHandle, menu_id: String) {
     let rpc = app.state::<RpcMutex>().inner();
     let pause_state = app.state::<Arc<PauseState>>().inner();
 
-    let mut rpc = rpc.lock().await;
+    let rpc = rpc.lock().await;
     let is_paused = pause_state.clone();
 
     match rpc
@@ -276,10 +276,7 @@ async fn pause_crawler(app: AppHandle, menu_id: String) {
             let _ = item_handle.set_title(new_label);
             let _ = item_handle.set_enabled(true);
         }
-        Err(err) => {
-            log::error!("Error sending RPC: {}", err);
-            rpc.reconnect().await;
-        }
+        Err(err) => log::error!("Error sending RPC: {}", err),
     }
 }
 

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -23,7 +23,7 @@ use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 use cocoa::appkit::NSWindow;
 
 use shared::config::Config;
-use shared::rpc::RpcClient;
+use spyglass_rpc::RpcClient;
 
 mod cmd;
 mod constants;

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -11,6 +11,9 @@ use migration::Migrator;
 use shared::response::AppStatus;
 use shared::{config::Config, response};
 use spyglass_rpc::RpcClient;
+use crate::rpc::SpyglassServerClient;
+
+
 const TRAY_UPDATE_INTERVAL_S: u64 = 60;
 
 use crate::{
@@ -100,9 +103,9 @@ async fn run_and_check_backend(app_handle: AppHandle) {
     progress.set("Waiting for backend...");
 
     let config = app_handle.state::<Config>();
-    let rpc = rpc::RpcClient::new(&config).await;
-
-    app_handle.manage(RpcMutex::new(Mutex::new(rpc)));
+    let rpc = SpyglassServerClient::new(&config).await;
+    let rpc_mutex = RpcMutex::new(Mutex::new(rpc));
+    app_handle.manage(rpc_mutex.clone());
 
     // Will cancel and clear any interval checks in the client
     progress.set("DONE");

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -8,9 +8,9 @@ use tokio::sync::Mutex;
 use tokio::time::{self, Duration};
 
 use migration::Migrator;
+use shared::response;
 use shared::response::AppStatus;
-use shared::{response, rpc::RpcClient};
-
+use spyglass_rpc::RpcClient;
 const TRAY_UPDATE_INTERVAL_S: u64 = 60;
 
 use crate::{

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -8,8 +8,8 @@ use tokio::sync::Mutex;
 use tokio::time::{self, Duration};
 
 use migration::Migrator;
-use shared::response;
 use shared::response::AppStatus;
+use shared::{config::Config, response};
 use spyglass_rpc::RpcClient;
 const TRAY_UPDATE_INTERVAL_S: u64 = 60;
 
@@ -98,7 +98,10 @@ async fn run_and_check_backend(app_handle: AppHandle) {
     // Wait for the server to boot up
     log::info!("Waiting for server backend");
     progress.set("Waiting for backend...");
-    let rpc = rpc::RpcClient::new().await;
+
+    let config = app_handle.state::<Config>();
+    let rpc = rpc::RpcClient::new(&config).await;
+
     app_handle.manage(RpcMutex::new(Mutex::new(rpc)));
 
     // Will cancel and clear any interval checks in the client

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -7,12 +7,11 @@ use tauri::{
 use tokio::sync::Mutex;
 use tokio::time::{self, Duration};
 
+use crate::rpc::SpyglassServerClient;
 use migration::Migrator;
 use shared::response::AppStatus;
 use shared::{config::Config, response};
 use spyglass_rpc::RpcClient;
-use crate::rpc::SpyglassServerClient;
-
 
 const TRAY_UPDATE_INTERVAL_S: u64 = 60;
 
@@ -106,6 +105,7 @@ async fn run_and_check_backend(app_handle: AppHandle) {
     let rpc = SpyglassServerClient::new(&config).await;
     let rpc_mutex = RpcMutex::new(Mutex::new(rpc));
     app_handle.manage(rpc_mutex.clone());
+    tauri::async_runtime::spawn(SpyglassServerClient::daemon_eyes(rpc_mutex));
 
     // Will cancel and clear any interval checks in the client
     progress.set("DONE");

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use shared::config::Config;
 use tauri::api::process::{Command, CommandEvent};
 use tauri::async_runtime::JoinHandle;
 use tokio::sync::Mutex;
@@ -31,9 +32,9 @@ async fn try_connect(endpoint: &str) -> anyhow::Result<HttpClient> {
 }
 
 impl RpcClient {
-    pub async fn new() -> Self {
-        log::info!("Connecting to backend");
-        let endpoint = "http://127.0.0.1:1234".to_string();
+    pub async fn new(config: &Config) -> Self {
+        let endpoint = format!("http://127.0.0.1:{}", config.user_settings.port);
+        log::info!("Connecting to backend @ {}", &endpoint);
 
         // Only startup & manage sidecar in release mode.
         #[cfg(not(debug_assertions))]

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -39,6 +39,7 @@ impl RpcClient {
         #[cfg(not(debug_assertions))]
         let sidecar_handle = Some(RpcClient::check_and_start_backend());
 
+        log::info!("backend started");
         let client = try_connect(&endpoint)
             .await
             .expect("Unable to connect to spyglass backend!");


### PR DESCRIPTION
### Key things updated
- Working towards #26 & #179
- [x] Migrating from old `jsonrpc` lib to `jsonrpsee`
- [x] Moving off of unix sockets / windows named pipes to http support. Just more reliable in the end.
- [x] Better search daemon monitoring
- [x] Address/port user settings