### PR TITLE
feature: smarter file indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,6 +5194,7 @@ version = "0.1.1"
 dependencies = [
  "ron",
  "serde",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,15 +664,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -735,6 +746,16 @@ dependencies = [
  "foreign-types",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1043,6 +1064,50 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "cxx"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "darling"
@@ -2343,6 +2408,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde6edd6cef363e9359ed3c98ba64590ba9eecba2293eb5a723ab32aee8926aa"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "ico"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,9 +2952,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "local-file-indexer"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "spyglass-plugin",
@@ -4434,6 +4533,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"

--- a/assets/plugins/local-file-indexer/manifest.ron
+++ b/assets/plugins/local-file-indexer/manifest.ron
@@ -12,6 +12,12 @@
             value: "",
             form_type: PathList,
             help_text: Some("List of folders that will be crawled & indexed. These folders will be crawled recursively, so you only need to specify the parent folder.")
+        ),
+        "EXTS_LIST": (
+            label: "File Types",
+            value: "[\"md\", \"txt\"]",
+            form_type: StringList,
+            help_text: Some("List of supported file types that will be indexed.")
         )
     }
 )

--- a/crates/client/src/pages/settings.rs
+++ b/crates/client/src/pages/settings.rs
@@ -96,7 +96,7 @@ pub fn setting_form(props: &SettingFormProps) -> Html {
             <div>
                 {
                     match &props.opts.form_type {
-                        FormType::PathList => {
+                        FormType::PathList | FormType::StringList => {
                             html! {
                                 <textarea
                                     ref={input_ref.clone()}

--- a/crates/shared/src/form.rs
+++ b/crates/shared/src/form.rs
@@ -19,7 +19,9 @@ impl FormType {
                 let value = value.replace('\\', "\\\\");
                 // Validate the value by attempting to deserialize
                 match serde_json::from_str::<Vec<String>>(&value) {
-                    Ok(parsed) => Ok(serde_json::to_string::<Vec<String>>(&parsed).expect("Invalid list")),
+                    Ok(parsed) => {
+                        Ok(serde_json::to_string::<Vec<String>>(&parsed).expect("Invalid list"))
+                    }
                     Err(e) => Err(e.to_string()),
                 }
             }

--- a/crates/shared/src/form.rs
+++ b/crates/shared/src/form.rs
@@ -4,6 +4,7 @@ use strum_macros::{Display, EnumString};
 
 #[derive(Clone, Debug, Display, EnumString, PartialEq, Serialize, Deserialize, Eq)]
 pub enum FormType {
+    StringList,
     Path,
     PathList,
     Text,
@@ -13,6 +14,15 @@ impl FormType {
     pub fn validate(&self, value: &str) -> Result<String, String> {
         let value = value.trim();
         match self {
+            FormType::StringList => {
+                // Escape backslashes
+                let value = value.replace('\\', "\\\\");
+                // Validate the value by attempting to deserialize
+                match serde_json::from_str::<Vec<String>>(&value) {
+                    Ok(parsed) => Ok(serde_json::to_string::<Vec<String>>(&parsed).expect("Invalid list")),
+                    Err(e) => Err(e.to_string()),
+                }
+            }
             FormType::Path => {
                 // Escape backslashes
                 let value = value.replace('\\', "\\\\");

--- a/crates/spyglass-plugin/Cargo.toml
+++ b/crates/spyglass-plugin/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 ron = "0.8"
+url = "2.2"
 
 [lib]
 name = "spyglass_plugin"

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 pub mod consts;
+pub mod utils;
 mod shims;
 
 use serde::{Deserialize, Serialize};

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 use std::fmt;
+use std::path::PathBuf;
 
 pub mod consts;
-pub mod utils;
 mod shims;
+pub mod utils;
 
 use serde::{Deserialize, Serialize};
 pub use shims::*;
@@ -96,9 +97,9 @@ impl fmt::Display for PluginSubscription {
 pub enum PluginEvent {
     IntervalUpdate,
     // File watcher updates
-    FileCreated(String),
-    FileUpdated(String),
-    FileDeleted(String),
+    FileCreated(PathBuf),
+    FileUpdated(PathBuf),
+    FileDeleted(PathBuf),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -68,7 +68,7 @@ pub enum PluginSubscription {
     /// Check for updates at a fixed interval
     CheckUpdateInterval,
     WatchDirectory {
-        path: String,
+        path: PathBuf,
         recurse: bool,
     },
 }
@@ -82,7 +82,7 @@ impl fmt::Display for PluginSubscription {
             PluginSubscription::WatchDirectory { path, recurse } => write!(
                 f,
                 "<WatchDirectory {} - {}>",
-                path,
+                path.display(),
                 if *recurse {
                     "recursive"
                 } else {
@@ -130,7 +130,7 @@ pub enum PluginCommandRequest {
     },
     // Walk & enqueue the contents of a directory
     WalkAndEnqueue {
-        path: String,
+        path: PathBuf,
         extensions: HashSet<String>,
     },
 }

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -1,8 +1,11 @@
+use std::collections::HashSet;
+use std::fmt;
+
 pub mod consts;
 mod shims;
+
 use serde::{Deserialize, Serialize};
 pub use shims::*;
-use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SearchFilter {
@@ -126,7 +129,7 @@ pub enum PluginCommandRequest {
     // Walk & enqueue the contents of a directory
     WalkAndEnqueue {
         path: String,
-        extensions: Vec<String>,
+        extensions: HashSet<String>,
     },
 }
 

--- a/crates/spyglass-plugin/src/lib.rs
+++ b/crates/spyglass-plugin/src/lib.rs
@@ -99,18 +99,35 @@ pub enum PluginEvent {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PluginCommandRequest {
-    DeleteDoc { url: String },
+    DeleteDoc {
+        url: String,
+    },
     // Enqueue a list of URLs into the crawl queue
-    Enqueue { urls: Vec<String> },
-    // List the contents of a directory
-    ListDir { path: String },
+    Enqueue {
+        urls: Vec<String>,
+    },
+    // Ask host to list the contents of a directory
+    ListDir {
+        path: String,
+    },
     // Subscribe to PluginEvents
     Subscribe(PluginSubscription),
     // Run a sqlite query on a db file. NOTE: This is a workaround due to the fact
     // that sqlite can not be easily compiled to wasm... yet!
-    SqliteQuery { path: String, query: String },
+    SqliteQuery {
+        path: String,
+        query: String,
+    },
     // Request mounting a file & its contents to the plugin VFS
-    SyncFile { dst: String, src: String },
+    SyncFile {
+        dst: String,
+        src: String,
+    },
+    // Walk & enqueue the contents of a directory
+    WalkAndEnqueue {
+        path: String,
+        extensions: Vec<String>,
+    },
 }
 
 #[derive(Deserialize, Serialize)]

--- a/crates/spyglass-plugin/src/shims.rs
+++ b/crates/spyglass-plugin/src/shims.rs
@@ -1,4 +1,5 @@
 use serde::{de::DeserializeOwned, Serialize};
+use std::collections::HashSet;
 use std::io;
 
 use crate::{ListDirEntry, PluginCommandRequest, PluginSubscription};
@@ -51,11 +52,11 @@ pub fn list_dir(path: &str) -> Result<Vec<ListDirEntry>, ron::error::SpannedErro
 /// Recursively walk & enqueue contents of a path.
 pub fn walk_and_enqueue_dir(
     path: &str,
-    extensions: &[String],
+    extensions: &HashSet<String>,
 ) -> Result<(), ron::error::SpannedError> {
     if object_to_stdout(&PluginCommandRequest::WalkAndEnqueue {
         path: path.to_string(),
-        extensions: extensions.into(),
+        extensions: extensions.clone(),
     })
     .is_ok()
     {

--- a/crates/spyglass-plugin/src/shims.rs
+++ b/crates/spyglass-plugin/src/shims.rs
@@ -32,7 +32,7 @@ pub fn enqueue_all(urls: &[String]) {
     }
 }
 
-/// List dir
+/// List contents of a directory.
 pub fn list_dir(path: &str) -> Result<Vec<ListDirEntry>, ron::error::SpannedError> {
     if object_to_stdout(&PluginCommandRequest::ListDir {
         path: path.to_string(),
@@ -46,6 +46,25 @@ pub fn list_dir(path: &str) -> Result<Vec<ListDirEntry>, ron::error::SpannedErro
     }
 
     Ok(Vec::new())
+}
+
+/// Recursively walk & enqueue contents of a path.
+pub fn walk_and_enqueue_dir(
+    path: &str,
+    extensions: &[String],
+) -> Result<(), ron::error::SpannedError> {
+    if object_to_stdout(&PluginCommandRequest::WalkAndEnqueue {
+        path: path.to_string(),
+        extensions: extensions.into(),
+    })
+    .is_ok()
+    {
+        unsafe {
+            plugin_cmd();
+        }
+    }
+
+    Ok(())
 }
 
 /// Utility function to log to spyglass logs

--- a/crates/spyglass-plugin/src/shims.rs
+++ b/crates/spyglass-plugin/src/shims.rs
@@ -1,6 +1,6 @@
 use serde::{de::DeserializeOwned, Serialize};
-use std::collections::HashSet;
 use std::io;
+use std::{collections::HashSet, path::PathBuf};
 
 use crate::{ListDirEntry, PluginCommandRequest, PluginSubscription};
 
@@ -51,11 +51,11 @@ pub fn list_dir(path: &str) -> Result<Vec<ListDirEntry>, ron::error::SpannedErro
 
 /// Recursively walk & enqueue contents of a path.
 pub fn walk_and_enqueue_dir(
-    path: &str,
+    path: PathBuf,
     extensions: &HashSet<String>,
 ) -> Result<(), ron::error::SpannedError> {
     if object_to_stdout(&PluginCommandRequest::WalkAndEnqueue {
-        path: path.to_string(),
+        path,
         extensions: extensions.clone(),
     })
     .is_ok()

--- a/crates/spyglass-plugin/src/utils.rs
+++ b/crates/spyglass-plugin/src/utils.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+use url::Url;
+
+// Create a file URI
+pub fn path_to_uri(path: PathBuf) -> String {
+    let path_str = path.to_str().expect("Unable to convert path to string");
+
+    // Eventually this will be away to keep track of multiple devices and searching across
+    // them. Might make sense to generate a UUID and assign to this computer(?) hostname
+    // can be changed by the user.
+    let host = if let Ok(hname) = std::env::var("HOST_NAME") {
+        hname
+    } else {
+        "home.local".into()
+    };
+
+    let mut new_url = Url::parse("file://").expect("Base URI");
+    let _ = new_url.set_host(Some(&host));
+    // Fixes issues handling windows drive letters
+    new_url.set_path(&path_str.replace(':', "%3A"));
+    new_url.to_string()
+}

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -200,12 +200,7 @@ pub struct WalkStats {
     pub skipped: i32,
 }
 
-fn handle_walk_and_enqueue(path: PathBuf, extensions: &[String]) -> WalkStats {
-    let exts: HashSet<String> = extensions
-        .iter()
-        .map(|x| x.to_owned())
-        .collect::<HashSet<String>>();
-
+fn handle_walk_and_enqueue(path: PathBuf, supported_exts: &HashSet<String>) -> WalkStats {
     let walker = WalkBuilder::new(path).standard_filters(true).build();
 
     let mut stats = WalkStats::default();
@@ -219,7 +214,7 @@ fn handle_walk_and_enqueue(path: PathBuf, extensions: &[String]) -> WalkStats {
             let ext = entry.path().extension().and_then(|ext| ext.to_str());
 
             if let Some(ext) = ext {
-                if exts.contains(ext) {
+                if supported_exts.contains(ext) {
                     stats.files += 1;
                 } else {
                     stats.skipped += 1;
@@ -234,11 +229,14 @@ fn handle_walk_and_enqueue(path: PathBuf, extensions: &[String]) -> WalkStats {
 #[cfg(test)]
 mod test {
     use super::handle_walk_and_enqueue;
+    use std::collections::HashSet;
     use std::path::Path;
 
     #[test]
     fn test_walk_and_enqueue() {
-        let ext = vec!["md".into(), "txt".into()];
+        let ext: HashSet<String> =
+            HashSet::from_iter(vec!["md".into(), "txt".into()].iter().cloned());
+
         let path = Path::new("/Users/a5huynh/Documents");
         let stats = handle_walk_and_enqueue(path.to_path_buf(), &ext);
         println!("stats: {:?}", stats);

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -58,7 +58,7 @@ async fn handle_plugin_cmd_request(
         // Enqueue a list of URLs to be crawled
         PluginCommandRequest::Enqueue { urls } => handle_plugin_enqueue(env, urls),
         PluginCommandRequest::ListDir { path } => {
-            log::info!("{} ListDir path: {}", env.name, path);
+            log::info!("{} listing path: {}", env.name, path);
             let entries = std::fs::read_dir(path)?
                 .flatten()
                 .map(|entry| {
@@ -233,14 +233,14 @@ fn handle_walk_and_enqueue(path: PathBuf, extensions: &[String]) -> WalkStats {
 
 #[cfg(test)]
 mod test {
-    use super::handle_list_dir;
+    use super::handle_walk_and_enqueue;
     use std::path::Path;
 
     #[test]
-    fn test_list_dir() {
+    fn test_walk_and_enqueue() {
         let ext = vec!["md".into(), "txt".into()];
         let path = Path::new("/Users/a5huynh/Documents");
-        let stats = handle_list_dir(path.to_path_buf(), &ext);
+        let stats = handle_walk_and_enqueue(path.to_path_buf(), &ext);
         println!("stats: {:?}", stats);
     }
 }

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -109,10 +109,10 @@ async fn handle_plugin_cmd_request(
         PluginCommandRequest::WalkAndEnqueue { path, extensions } => {
             let dir_path = Path::new(&path);
             if !dir_path.exists() {
-                return Err(Error::msg(format!("Invalid path: {}", path)));
+                return Err(Error::msg(format!("Invalid path: {}", path.display())));
             }
 
-            log::info!("{} crawling path: {}", env.name, path);
+            log::info!("{} crawling path: {}", env.name, path.display());
             let stats =
                 handle_walk_and_enqueue(&env.app_state, dir_path.to_path_buf(), extensions).await;
             wasi_write(&env.wasi_env, &stats)?;

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -15,7 +15,7 @@ use crate::search::Searcher;
 use crate::state::AppState;
 
 use entities::models::crawl_queue::{enqueue_all, EnqueueSettings};
-use spyglass_plugin::{ListDirEntry, PluginCommandRequest, utils::path_to_uri};
+use spyglass_plugin::{utils::path_to_uri, ListDirEntry, PluginCommandRequest};
 
 pub fn register_exports(
     plugin_id: PluginId,
@@ -262,6 +262,7 @@ async fn handle_walk_and_enqueue(
         .await;
     }
 
+    log::info!("walked & enqueued: {:?}", stats);
     stats
 }
 
@@ -271,10 +272,10 @@ mod test {
     use std::path::Path;
 
     use super::handle_walk_and_enqueue;
-    use crate::state::AppStateBuilder;
     use crate::search::IndexPath;
+    use crate::state::AppStateBuilder;
+    use entities::models::crawl_queue::{num_queued, CrawlStatus};
     use entities::test::setup_test_db;
-    use entities::models::crawl_queue::{CrawlStatus, num_queued};
     use shared::config::UserSettings;
 
     #[tokio::test]
@@ -294,7 +295,9 @@ mod test {
         assert!(stats.files > 0);
 
         // Crawl queue should have the same number of documents
-        let num_queued = num_queued(&state.db, CrawlStatus::Queued).await.expect("Unable to query queue");
+        let num_queued = num_queued(&state.db, CrawlStatus::Queued)
+            .await
+            .expect("Unable to query queue");
         assert_eq!(num_queued, stats.files as u64);
     }
 }

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -113,7 +113,7 @@ impl PluginInstance {
 
 pub struct PluginManager {
     check_update_subs: HashSet<PluginId>,
-    file_watch_subs: DashMap<PluginId, String>,
+    file_watch_subs: DashMap<PluginId, PathBuf>,
     plugins: DashMap<PluginId, PluginInstance>,
     // For file watching subscribers
     file_events: Receiver<notify::Result<notify::Event>>,
@@ -276,15 +276,14 @@ pub async fn plugin_event_loop(
                         .await;
                 }
                 PluginSubscription::WatchDirectory { path, recurse } => {
-                    let dir_path = Path::new(&path);
                     // Ignore invalid directory paths
-                    if !dir_path.exists() || !dir_path.is_dir() {
-                        log::warn!("Ignoring invalid path: {}", path);
+                    if !path.exists() || !path.is_dir() {
+                        log::warn!("Ignoring invalid path: {}", path.display());
                         return;
                     }
 
                     let _ = manager.file_watcher.watch(
-                        dir_path,
+                        &path,
                         if recurse {
                             RecursiveMode::Recursive
                         } else {

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -316,7 +316,11 @@ pub async fn plugin_event_loop(
                 }
 
                 for updated_path in file_event.paths {
-                    let updated_path = updated_path.display().to_string();
+                    log::trace!(
+                        "notifying plugins of file_event: {:?} for <{}>",
+                        file_event.kind,
+                        updated_path.display()
+                    );
 
                     let event = match &file_event.kind {
                         EventKind::Create(_) => {

--- a/plugins/local-file-indexer/Cargo.toml
+++ b/plugins/local-file-indexer/Cargo.toml
@@ -8,6 +8,7 @@ name = "local-file-indexer"
 path = "src/main.rs"
 
 [dependencies]
+chrono = { version = "0.4.22", features = ["serde", "wasmbind"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 spyglass-plugin = { path = "../../crates/spyglass-plugin" }

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -11,13 +11,25 @@ struct Plugin {
 
 const PLUGIN_DATA: &str = "/data.json";
 const FOLDERS_LIST_ENV: &str = "FOLDERS_LIST";
+const EXTS_LIST_ENV: &str = "EXTS_LIST";
 
 register_plugin!(Plugin);
 
 impl SpyglassPlugin for Plugin {
     fn load(&mut self) {
-        // TODO: Make this configurable.
-        self.extensions = HashSet::from_iter(vec!["md".to_string(), "txt".to_string()].into_iter());
+        // List of supported file types
+        let default_exts =
+            HashSet::from_iter(vec!["md".to_string(), "txt".to_string()].into_iter());
+        self.extensions = if let Ok(blob) = std::env::var(EXTS_LIST_ENV) {
+            if let Ok(exts) = serde_json::from_str(&blob) {
+                exts
+            } else {
+                default_exts
+            }
+        } else {
+            default_exts
+        };
+
         // List of paths being checked.
         self.processed_paths = match std::fs::read_to_string(PLUGIN_DATA) {
             Ok(blob) => {

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -61,7 +61,9 @@ impl Plugin {
 
 impl SpyglassPlugin for Plugin {
     fn load(&mut self) {
+        // TODO: Make this configurable.
         self.extensions = HashSet::from_iter(vec!["md".to_string(), "txt".to_string()].into_iter());
+        // List of paths being checked.
         self.processed_paths = match std::fs::read_to_string(PLUGIN_DATA) {
             Ok(blob) => {
                 if let Ok(paths) = serde_json::from_str::<HashSet<String>>(&blob) {

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -1,17 +1,25 @@
-use std::collections::HashSet;
+use chrono::prelude::*;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use spyglass_plugin::utils::path_to_uri;
 use spyglass_plugin::*;
 
 #[derive(Default)]
 struct Plugin {
     extensions: HashSet<String>,
-    processed_paths: HashSet<String>,
+    last_synced: SyncData,
 }
 
 const PLUGIN_DATA: &str = "/data.json";
 const FOLDERS_LIST_ENV: &str = "FOLDERS_LIST";
 const EXTS_LIST_ENV: &str = "EXTS_LIST";
+
+#[derive(Default, Deserialize, Serialize)]
+struct SyncData {
+    path_to_times: HashMap<PathBuf, DateTime<Utc>>,
+}
 
 register_plugin!(Plugin);
 
@@ -30,47 +38,46 @@ impl SpyglassPlugin for Plugin {
             default_exts
         };
 
-        // List of paths being checked.
-        self.processed_paths = match std::fs::read_to_string(PLUGIN_DATA) {
-            Ok(blob) => {
-                if let Ok(paths) = serde_json::from_str::<HashSet<String>>(&blob) {
-                    paths
-                } else {
-                    HashSet::new()
-                }
-            }
-            Err(_) => HashSet::new(),
+        // When paths were last synced
+        self.last_synced = if let Ok(blob) = std::fs::read_to_string(PLUGIN_DATA) {
+            serde_json::from_str::<SyncData>(&blob).map_or(Default::default(), |x| x)
+        } else {
+            Default::default()
         };
 
         let paths = if let Ok(blob) = std::env::var(FOLDERS_LIST_ENV) {
-            if let Ok(folders) = serde_json::from_str::<Vec<String>>(&blob) {
-                folders
-            } else {
-                Vec::new()
-            }
+            serde_json::from_str::<Vec<String>>(&blob).map_or(Vec::new(), |x| x)
         } else {
             Vec::new()
         };
 
-        for path in paths {
-            // Have we processed this directory?
-            if !self.processed_paths.contains(&path) {
-                if let Err(e) = walk_and_enqueue_dir(&path, &self.extensions) {
+        for path in paths.iter().map(|path| Path::new(&path).to_path_buf()) {
+            let now = Utc::now();
+
+            let last_processed_time = self
+                .last_synced
+                .path_to_times
+                .entry(path.to_path_buf())
+                .or_default();
+
+            let diff = now - *last_processed_time;
+            if diff.num_days() > 1 {
+                if let Err(e) = walk_and_enqueue_dir(path.to_path_buf(), &self.extensions) {
                     log(format!("Unable to process dir: {}", e));
                 } else {
-                    self.processed_paths.insert(path.to_string());
+                    *last_processed_time = now;
                 }
             }
 
             // List to notifications
             subscribe(PluginSubscription::WatchDirectory {
-                path: path.to_string(),
+                path: path.to_path_buf(),
                 recurse: true,
             });
         }
 
         // Save list of processed paths to data dir
-        if let Ok(blob) = serde_json::to_string_pretty(&self.processed_paths) {
+        if let Ok(blob) = serde_json::to_string_pretty(&self.last_synced) {
             let _ = std::fs::write(PLUGIN_DATA, blob);
         }
     }

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -1,8 +1,7 @@
 use std::collections::HashSet;
-use std::path::Path;
 
-use spyglass_plugin::*;
 use spyglass_plugin::utils::path_to_uri;
+use spyglass_plugin::*;
 
 #[derive(Default)]
 struct Plugin {
@@ -67,9 +66,13 @@ impl SpyglassPlugin for Plugin {
     fn update(&mut self, event: PluginEvent) {
         match event {
             PluginEvent::FileCreated(path) | PluginEvent::FileUpdated(path) => {
-                enqueue_all(&[path_to_uri(Path::new(&path).to_path_buf())])
+                if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+                    if self.extensions.contains(ext) {
+                        enqueue_all(&[path_to_uri(path)])
+                    }
+                }
             }
-            PluginEvent::FileDeleted(path) => delete_doc(&path_to_uri(Path::new(&path).to_path_buf())),
+            PluginEvent::FileDeleted(path) => delete_doc(&path_to_uri(path)),
             _ => {}
         }
     }

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -57,12 +57,10 @@ impl SpyglassPlugin for Plugin {
             Vec::new()
         };
 
-        let exts: Vec<String> = self.extensions.iter().map(|x| x.to_owned()).collect();
-
         for path in paths {
             // Have we processed this directory?
             if !self.processed_paths.contains(&path) {
-                if let Err(e) = walk_and_enqueue_dir(&path, &exts) {
+                if let Err(e) = walk_and_enqueue_dir(&path, &self.extensions) {
                     log(format!("Unable to process dir: {}", e));
                 } else {
                     self.processed_paths.insert(path.to_string());


### PR DESCRIPTION
Saner defaults & moved the heavy lifting from plugin to core.
- Initial walk & enqueue will take into account `.gitgnore`'s and will walk directories in parallel.
- Watching file updates is now a little smarter.
- User can configure supported file types.