### PR TITLE
tweak: index commit task cleanup

### DIFF
--- a/crates/migrations/src/m20221023_000001_connection_table.rs
+++ b/crates/migrations/src/m20221023_000001_connection_table.rs
@@ -17,7 +17,7 @@ impl MigrationTrait for Migration {
             CREATE TABLE IF NOT EXISTS "connections" (
                 "id" text NOT NULL PRIMARY KEY,
                 "access_token" text NOT NULL,
-                "refresh_token" text NOT NULL,
+                "refresh_token" text,
                 "scopes" text NOT NULL,
                 "expires_in" integer,
                 "granted_at" text NOT NULL,

--- a/crates/spyglass/src/connection/mod.rs
+++ b/crates/spyglass/src/connection/mod.rs
@@ -62,8 +62,10 @@ impl DriveConnection {
                         {
                             let mut update: connection::ActiveModel = conn.into();
                             update.access_token = Set(new_creds.access_token.secret().to_string());
-                            update.refresh_token =
-                                Set(new_creds.refresh_token.map(|t| t.secret().to_string()));
+                            // Refresh tokens are optionally sent
+                            if let Some(refresh_token) = new_creds.refresh_token {
+                                update.refresh_token = Set(Some(refresh_token.secret().to_string()));
+                            }
                             update.expires_in = Set(new_creds
                                 .expires_in
                                 .map_or_else(|| None, |dur| Some(dur.as_secs() as i64)));

--- a/crates/spyglass/src/connection/mod.rs
+++ b/crates/spyglass/src/connection/mod.rs
@@ -64,7 +64,8 @@ impl DriveConnection {
                             update.access_token = Set(new_creds.access_token.secret().to_string());
                             // Refresh tokens are optionally sent
                             if let Some(refresh_token) = new_creds.refresh_token {
-                                update.refresh_token = Set(Some(refresh_token.secret().to_string()));
+                                update.refresh_token =
+                                    Set(Some(refresh_token.secret().to_string()));
                             }
                             update.expires_in = Set(new_creds
                                 .expires_in

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -1,7 +1,5 @@
 extern crate notify;
-//use crate::importer::FirefoxImporter;
 use std::io;
-use std::time::Duration;
 use tokio::signal;
 use tokio::sync::{broadcast, mpsc};
 use tracing_log::LogTracer;
@@ -202,28 +200,6 @@ async fn start_backend(state: &mut AppState, config: &Config) {
         pipeline_cmd_rx,
         shutdown_tx.clone(),
     ));
-
-    // Clean up crew. Commit anything added to the index in the last 10s
-    // TODO: Make this smarter...
-    {
-        let state = state.clone();
-        let _ = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(10));
-
-            loop {
-                interval.tick().await;
-                if let Err(err) = state
-                    .index
-                    .writer
-                    .lock()
-                    .expect("Unable to get index lock")
-                    .commit()
-                {
-                    log::error!("commit loop error: {:?}", err);
-                }
-            }
-        });
-    }
 
     // Plugin server
     let pm_handle = tokio::spawn(plugin::plugin_event_loop(

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use notify::event::ModifyKind;
 use notify::{EventKind, RecursiveMode, Watcher};
 use tokio::sync::{broadcast, mpsc};
@@ -8,6 +9,7 @@ use crate::connection::{Connection, DriveConnection};
 use crate::crawler::bootstrap;
 use crate::search::lens::{load_lenses, read_lenses};
 use crate::state::AppState;
+use crate::task::worker::FetchResult;
 
 mod manager;
 mod worker;
@@ -42,6 +44,8 @@ pub enum ManagerCommand {
 #[derive(Clone, Debug)]
 pub enum WorkerCommand {
     Collect(CollectTask),
+    // Commit any changes that have been made to the index.
+    CommitIndex,
     // Fetch, parses, & indexes a URI
     // TODO: Split this up so that this work can be spread out.
     Crawl { id: i64 },
@@ -70,7 +74,10 @@ pub async fn manager_task(
     mut shutdown_rx: broadcast::Receiver<AppShutdown>,
 ) {
     log::info!("manager started");
-    let mut queue_check_interval = tokio::time::interval(std::time::Duration::from_millis(100));
+
+    let mut queue_check_interval = tokio::time::interval(Duration::from_millis(100));
+    let mut commit_check_interval = tokio::time::interval(Duration::from_secs(10));
+
     loop {
         tokio::select! {
             // Listen for manager level commands. This can be sent internally (i.e. CheckForJobs) or
@@ -79,17 +86,19 @@ pub async fn manager_task(
                 if let Some(cmd) = cmd {
                     match cmd {
                         ManagerCommand::Collect(task) => {
-                            log::debug!("collecting URIs");
                             if let Err(err) = queue.send(WorkerCommand::Collect(task)).await {
                                 log::error!("Unable to send worker cmd: {}", err.to_string());
                             }
                         }
                         ManagerCommand::CheckForJobs => {
-                            // log::debug!("checking for new jobs");
                             manager::check_for_jobs(&state, &queue).await
                         }
                     }
                 }
+            }
+            // Check for changes to the index & commit them
+            _ = commit_check_interval.tick() => {
+                let _ = queue.send(WorkerCommand::CommitIndex).await;
             }
             // If we're not handling anything, continually poll for jobs.
             _ = queue_check_interval.tick() => {
@@ -115,6 +124,7 @@ pub async fn worker_task(
 ) {
     log::info!("worker started");
     let mut is_paused = false;
+    let mut updated_docs = 0;
 
     loop {
         // Run w/ a select on the shutdown signal otherwise we're stuck in an
@@ -154,7 +164,6 @@ pub async fn worker_task(
         };
 
         if let Some(cmd) = next_cmd {
-            log::debug!("handling command: {:?}", cmd);
             match cmd {
                 WorkerCommand::Collect(task) => match task {
                     CollectTask::Bootstrap {
@@ -162,6 +171,7 @@ pub async fn worker_task(
                         seed_url,
                         pipeline,
                     } => {
+                        log::debug!("handling Bootstrap for {} - {}", lens, seed_url);
                         let state = state.clone();
                         tokio::spawn(async move {
                             if let Some(lens_config) = &state.lenses.get(&lens) {
@@ -188,8 +198,30 @@ pub async fn worker_task(
                         });
                     }
                 },
+                WorkerCommand::CommitIndex => {
+                    let state = state.clone();
+                    if updated_docs > 0 {
+                        log::debug!("committing {} new/updated docs in index", updated_docs);
+                        updated_docs = 0;
+                        tokio::spawn(async move {
+                            match state.index.writer.lock() {
+                                Ok(mut writer) => {
+                                    let _ = writer.commit();
+                                }
+                                Err(err) => {
+                                    log::debug!("Unable to acquire lock on index writer: {}", err.to_string())
+                                }
+                            }
+                        });
+                    }
+                }
                 WorkerCommand::Crawl { id } => {
-                    tokio::spawn(worker::handle_fetch(state.clone(), CrawlTask { id }));
+                    if let Ok(fetch_result) = tokio::spawn(worker::handle_fetch(state.clone(), CrawlTask { id })).await {
+                        match fetch_result {
+                            FetchResult::New | FetchResult::Updated => updated_docs += 1,
+                            _ => {}
+                        }
+                    }
                 }
                 WorkerCommand::Tag => {}
             }

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
 use notify::event::ModifyKind;
 use notify::{EventKind, RecursiveMode, Watcher};
+use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 
 use shared::config::Config;
@@ -209,14 +209,19 @@ pub async fn worker_task(
                                     let _ = writer.commit();
                                 }
                                 Err(err) => {
-                                    log::debug!("Unable to acquire lock on index writer: {}", err.to_string())
+                                    log::debug!(
+                                        "Unable to acquire lock on index writer: {}",
+                                        err.to_string()
+                                    )
                                 }
                             }
                         });
                     }
                 }
                 WorkerCommand::Crawl { id } => {
-                    if let Ok(fetch_result) = tokio::spawn(worker::handle_fetch(state.clone(), CrawlTask { id })).await {
+                    if let Ok(fetch_result) =
+                        tokio::spawn(worker::handle_fetch(state.clone(), CrawlTask { id })).await
+                    {
                         match fetch_result {
                             FetchResult::New | FetchResult::Updated => updated_docs += 1,
                             _ => {}

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -157,14 +157,13 @@ pub async fn handle_fetch(state: AppState, task: CrawlTask) -> FetchResult {
                         }
                     };
 
-
                     return match indexed.save(&state.db).await {
                         Ok(_) => FetchResult::Updated,
                         Err(e) => {
                             log::error!("Unable to save document: {}", e);
                             FetchResult::Error
                         }
-                    }
+                    };
                 } else {
                     return FetchResult::New;
                 }


### PR DESCRIPTION
- bugfix: remove null constraint from refresh token & only update if we are sent a new one.
- refactor: move index commit task into main event loop & keep track of new/updated docs 