### PR TITLE
bugfix: firefox importer paths & plugin settings save issue

### DIFF
--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -365,11 +365,12 @@ pub async fn save_user_settings(
                 }
                 plugin_name => {
                     // Load plugin settings configurations
-                    let plugin_config = plugin_configs
-                        .get(plugin_name)
-                        .expect("Unable to find plugin");
+                    if let Some(plugin_config) = plugin_configs.get(plugin_name) {
+                        let to_update = current_settings
+                            .plugin_settings
+                            .entry(plugin_name.to_string())
+                            .or_default();
 
-                    if let Some(to_update) = current_settings.plugin_settings.get_mut(plugin_name) {
                         if let Some(field_opts) = plugin_config.user_settings.get(field) {
                             // Validate & serialize value into something we can save.
                             match field_opts.form_type.validate(value) {
@@ -382,6 +383,8 @@ pub async fn save_user_settings(
                                 }
                             }
                         }
+                    } else {
+                        errors.insert(key.to_string(), format!("Config not found for {}", key));
                     }
                 }
             }

--- a/plugins/firefox-importer/src/main.rs
+++ b/plugins/firefox-importer/src/main.rs
@@ -93,7 +93,7 @@ impl Plugin {
                 "macos" => {
                     Some(Path::new(&home_dir).join("Library/Application Support/Firefox/Profiles"))
                 }
-                "windows" => Some(Path::new(&data_dir).join("Mozilla/Firefox/Profile/")),
+                "windows" => Some(Path::new(&data_dir).join("Mozilla\\Firefox\\Profile\\")),
                 _ => None,
             }
         } else {


### PR DESCRIPTION
- fix for default windows firefox path (slashes facing the wrong way 🤦‍♂️).
- fix for saving plugin settings if user settings are empty/default.