### PR TITLE
Update search query to use field tokenizer

### DIFF
--- a/crates/spyglass/src/search/mod.rs
+++ b/crates/spyglass/src/search/mod.rs
@@ -176,15 +176,17 @@ impl Searcher {
     pub async fn search_with_lens(
         _db: DatabaseConnection,
         applied_lenses: &Vec<SearchFilter>,
-        reader: &IndexReader,
+        searcher: &Searcher,
         query_string: &str,
     ) -> Vec<SearchResult> {
         let start_timer = Instant::now();
 
+        let index = &searcher.index;
+        let reader = &searcher.reader;
         let fields = DocFields::as_fields();
         let searcher = reader.searcher();
-
-        let query = build_query(fields.clone(), query_string);
+        let tokenizers = index.tokenizers().clone();
+        let query = build_query(index.schema(), tokenizers, fields.clone(), query_string);
 
         let mut allowed = Vec::new();
         let mut skipped = Vec::new();
@@ -375,7 +377,7 @@ mod test {
         _build_test_index(&mut searcher);
 
         let query = "salinas";
-        let results = Searcher::search_with_lens(db, &applied_lens, &searcher.reader, query).await;
+        let results = Searcher::search_with_lens(db, &applied_lens, &searcher, query).await;
         assert_eq!(results.len(), 1);
     }
 
@@ -400,7 +402,7 @@ mod test {
         _build_test_index(&mut searcher);
 
         let query = "salinas";
-        let results = Searcher::search_with_lens(db, &applied_lens, &searcher.reader, query).await;
+        let results = Searcher::search_with_lens(db, &applied_lens, &searcher, query).await;
         assert_eq!(results.len(), 1);
     }
 
@@ -426,7 +428,7 @@ mod test {
         _build_test_index(&mut searcher);
 
         let query = "salinas";
-        let results = Searcher::search_with_lens(db, &applied_lens, &searcher.reader, query).await;
+        let results = Searcher::search_with_lens(db, &applied_lens, &searcher, query).await;
         assert_eq!(results.len(), 0);
     }
 }

--- a/crates/spyglass/src/search/query.rs
+++ b/crates/spyglass/src/search/query.rs
@@ -1,15 +1,16 @@
-use tantivy::query::{BooleanQuery, BoostQuery, Occur, Query, TermQuery};
+use tantivy::query::{BooleanQuery, BoostQuery, Occur, PhraseQuery, Query, TermQuery};
 use tantivy::schema::*;
+use tantivy::tokenizer::TokenizerManager;
 use tantivy::Score;
 
 use super::DocFields;
 
 type QueryVec = Vec<(Occur, Box<dyn Query>)>;
 
-fn _boosted_term(field: Field, term: &str, boost: Score) -> Box<BoostQuery> {
+fn _boosted_term(term: Term, boost: Score) -> Box<BoostQuery> {
     Box::new(BoostQuery::new(
         Box::new(TermQuery::new(
-            Term::from_field_text(field, term),
+            term,
             // Needs WithFreqs otherwise scoring is wonky.
             IndexRecordOption::WithFreqs,
         )),
@@ -17,34 +18,74 @@ fn _boosted_term(field: Field, term: &str, boost: Score) -> Box<BoostQuery> {
     ))
 }
 
-pub fn build_query(fields: DocFields, query_string: &str) -> BooleanQuery {
-    // Tokenize query string
-    let query_string = query_string.to_lowercase();
-    let terms: Vec<&str> = query_string
-        .split(' ')
-        .into_iter()
-        .map(|token| token.trim())
-        .collect();
+fn _boosted_phrase(terms: Vec<Term>, boost: Score) -> Box<BoostQuery> {
+    Box::new(BoostQuery::new(Box::new(PhraseQuery::new(terms)), boost))
+}
+
+pub fn build_query(
+    schema: Schema,
+    tokenizers: TokenizerManager,
+    fields: DocFields,
+    query_string: &str,
+) -> BooleanQuery {
+    let content_terms = terms_for_field(&schema, &tokenizers, query_string, fields.content);
+    let title_terms: Vec<Term> = terms_for_field(&schema, &tokenizers, query_string, fields.title);
 
     let mut term_query: QueryVec = Vec::new();
 
     // Boost exact matches to the full query string
-    if terms.len() > 1 {
-        term_query.push((
-            Occur::Should,
-            _boosted_term(fields.title, &query_string, 5.0),
-        ));
-        term_query.push((
-            Occur::Should,
-            _boosted_term(fields.content, &query_string, 5.0),
-        ));
+    if content_terms.len() > 1 {
+        // boosting phrases relative to the number of segments in a
+        // continuous phrase
+        let boost = 2.0 * content_terms.len() as f32;
+        term_query.push((Occur::Should, _boosted_phrase(content_terms.clone(), boost)));
     }
 
-    for term in terms {
-        // Emphasize matches in the title more than words in the content
-        term_query.push((Occur::Should, _boosted_term(fields.content, term, 1.0)));
-        term_query.push((Occur::Should, _boosted_term(fields.title, term, 5.0)));
+    // Boost exact matches to the full query string
+    if title_terms.len() > 1 {
+        // boosting phrases relative to the number of segments in a
+        // continuous phrase, base score higher for title
+        // than content
+        let boost = 2.5 * title_terms.len() as f32;
+        term_query.push((Occur::Should, _boosted_phrase(title_terms.clone(), boost)));
+    }
+
+    for term in content_terms {
+        term_query.push((Occur::Should, _boosted_term(term, 1.0)));
+    }
+
+    for term in title_terms {
+        term_query.push((Occur::Should, _boosted_term(term, 2.0)));
     }
 
     BooleanQuery::new(vec![(Occur::Must, Box::new(BooleanQuery::new(term_query)))])
+}
+
+/**
+ * Responsible for parsing the input query for a particular field. The tokenizer for the field
+ * is used to ensure consistent tokens between indexing and queries.
+ */
+fn terms_for_field(
+    schema: &Schema,
+    tokenizers: &TokenizerManager,
+    query: &str,
+    field: Field,
+) -> Vec<Term> {
+    let mut terms = Vec::new();
+
+    let field_entry = schema.get_field_entry(field);
+    let field_type = field_entry.field_type();
+    if let FieldType::Str(ref str_options) = field_type {
+        let option = str_options.get_indexing_options().unwrap();
+        let text_analyzer = tokenizers.get(option.tokenizer()).unwrap();
+
+        let mut token_stream = text_analyzer.token_stream(query);
+        token_stream.process(&mut |token| {
+            log::error!("Term {:?}", token.text);
+            let term = Term::from_field_text(field, &token.text);
+            terms.push(term);
+        });
+    }
+
+    terms
 }


### PR DESCRIPTION
Search queries now use the tokenizer for the specific field to identify the search tokens. Phrase search is now used and boosted relative to the number of tokens in the query.