### PR TITLE
bugfix: Windows local file path bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "shared",
  "tantivy",
  "tar",
+ "url",
 ]
 
 [[package]]

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -432,15 +432,18 @@ pub async fn enqueue_all(
             let mut result = None;
             if !is_indexed.contains(&url) {
                 if let Ok(parsed) = Url::parse(&url) {
-                    if let Some(domain) = parsed.host_str() {
-                        result = Some(ActiveModel {
-                            domain: Set(domain.to_string()),
-                            crawl_type: Set(overrides.crawl_type.clone()),
-                            url: Set(url.to_string()),
-                            pipeline: Set(pipeline.clone()),
-                            ..Default::default()
-                        });
-                    }
+                    let domain = match parsed.scheme() {
+                        "file" => "localhost",
+                        _ => parsed.host_str().expect("Invalid URL host"),
+                    };
+
+                    result = Some(ActiveModel {
+                        domain: Set(domain.to_string()),
+                        crawl_type: Set(overrides.crawl_type.clone()),
+                        url: Set(url.to_string()),
+                        pipeline: Set(pipeline.clone()),
+                        ..Default::default()
+                    });
                 }
             }
             result

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -15,3 +15,4 @@ shared = { path = "../shared" }
 tantivy = "0.18"
 rayon = "1.5"
 tar = "0.4"
+url = "2.3"

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -14,6 +14,8 @@ mod m20221031_000001_add_error_column_to_crawl_queue;
 mod m20221101_000001_add_open_url_col;
 mod m20221107_000001_recreate_connection_table;
 mod m20221109_add_tags_table;
+mod m20221115_000001_local_file_pathfix;
+
 mod utils;
 
 pub struct Migrator;
@@ -33,6 +35,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221101_000001_add_open_url_col::Migration),
             Box::new(m20221107_000001_recreate_connection_table::Migration),
             Box::new(m20221109_add_tags_table::Migration),
+            Box::new(m20221115_000001_local_file_pathfix::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20221115_000001_local_file_pathfix.rs
+++ b/crates/migrations/src/m20221115_000001_local_file_pathfix.rs
@@ -1,0 +1,183 @@
+use entities::schema::{DocFields, SearchDocument};
+use sea_orm_migration::prelude::*;
+
+use entities::models::{crawl_queue, indexed_document};
+use entities::sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
+use shared::config::Config;
+use tantivy::collector::TopDocs;
+use tantivy::directory::MmapDirectory;
+use tantivy::query::TermQuery;
+use tantivy::schema::IndexRecordOption;
+use tantivy::{Document, Index, IndexReader, IndexWriter, ReloadPolicy, Term};
+use url::Url;
+
+pub struct Migration;
+
+impl Migration {
+    fn fix_url(&self, url: &str) -> Option<String> {
+        if let Ok(mut parsed) = Url::parse(url) {
+            // Switch host to localhost so that we can use `to_file_path`
+            let _ = parsed.set_host(Some("localhost"));
+
+            // If we're on Windows, fix the path bug we found where the `ignore`
+            // overescapes windows paths.
+            if cfg!(target_os = "windows") {
+                if let Ok(path_str) = parsed.to_file_path() {
+                    let path_str = path_str.display().to_string();
+                    parsed.set_path(&path_str.replace("\\\\", "\\"));
+                }
+            }
+
+            return Some(parsed.to_string());
+        }
+
+        None
+    }
+
+    fn open_index(&self) -> (IndexWriter, IndexReader) {
+        let config = Config::new();
+        let schema = DocFields::as_schema();
+
+        let dir = MmapDirectory::open(config.index_dir()).expect("Unable to create MmapDirectory");
+        let index = Index::open_or_create(dir, schema).expect("Unable to open / create directory");
+
+        let writer = index
+            .writer(50_000_000)
+            .expect("Unable to create index_writer");
+
+        // For a search server you will typically create on reader for the entire
+        // lifetime of your program.
+        let reader = index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::OnCommit)
+            .try_into()
+            .expect("Unable to create reader");
+
+        (writer, reader)
+    }
+
+    fn update_index(
+        &self,
+        writer: &IndexWriter,
+        reader: &IndexReader,
+        doc_id: &str,
+        updated_url: &str,
+    ) {
+        let fields = DocFields::as_fields();
+
+        let searcher = reader.searcher();
+        let query = TermQuery::new(
+            Term::from_field_text(fields.id, doc_id),
+            IndexRecordOption::Basic,
+        );
+
+        let res = searcher
+            .search(&query, &TopDocs::with_limit(1))
+            .map_or(Vec::new(), |x| x)
+            .pop();
+
+        let doc = if let Some((_, doc_address)) = res {
+            searcher.doc(doc_address).ok()
+        } else {
+            None
+        };
+
+        // Doc exists! Lets remove it and update it with the new URL
+        if let Some(doc) = doc {
+            // Remove the old one
+            writer.delete_term(Term::from_field_text(fields.id, doc_id));
+            // Re-add the document w/ the updated domain & url
+            let mut new_doc = Document::default();
+            new_doc.add_text(fields.id, doc_id);
+            new_doc.add_text(fields.domain, "localhost");
+            new_doc.add_text(fields.url, updated_url);
+            // Everything else stays the same
+            new_doc.add_text(
+                fields.content,
+                doc.get_first(fields.content).unwrap().as_text().unwrap(),
+            );
+            new_doc.add_text(
+                fields.description,
+                doc.get_first(fields.description)
+                    .unwrap()
+                    .as_text()
+                    .unwrap(),
+            );
+            new_doc.add_text(
+                fields.title,
+                doc.get_first(fields.title).unwrap().as_text().unwrap(),
+            );
+
+            let _ = writer.add_document(new_doc);
+        }
+    }
+}
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20221115_000001_local_file_pathfix"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let (mut iwriter, ireader) = self.open_index();
+        let db = manager.get_connection();
+
+        println!("Updating crawl_queue");
+        let queued = crawl_queue::Entity::find()
+            .filter(crawl_queue::Column::Url.starts_with("file://"))
+            .all(db)
+            .await
+            .expect("Unable to query crawl_queue table.");
+
+        for doc in &queued {
+            if let Some(updated_url) = self.fix_url(&doc.url) {
+                let mut update: crawl_queue::ActiveModel = doc.to_owned().into();
+                update.domain = Set("localhost".to_string());
+                update.url = Set(updated_url);
+                let _ = update.save(db).await;
+            }
+        }
+
+        let docs = indexed_document::Entity::find()
+            .filter(indexed_document::Column::Url.starts_with("file://"))
+            .all(db)
+            .await
+            .expect("Unable to query indexed_document table.");
+
+        // No docs yet, nothing to migrate.
+        if docs.is_empty() {
+            return Ok(());
+        }
+
+        println!("Updating index");
+        for doc in &docs {
+            if let Some(updated_url) = self.fix_url(&doc.url) {
+                // Update the document in the index
+                self.update_index(&iwriter, &ireader, &doc.doc_id, &updated_url);
+
+                // Update document in the db
+                let mut update: indexed_document::ActiveModel = doc.to_owned().into();
+                update.domain = Set("localhost".to_string());
+                update.url = Set(updated_url.clone());
+                update.open_url = Set(Some(updated_url.clone()));
+                let _ = update.save(db).await;
+            }
+        }
+
+        if let Err(err) = iwriter.commit() {
+            return Err(DbErr::Custom(format!(
+                "Unable to save changes to index: {}",
+                err
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/spyglass-plugin/src/utils.rs
+++ b/crates/spyglass-plugin/src/utils.rs
@@ -25,17 +25,29 @@ mod test {
     use url::Url;
 
     #[test]
-    #[cfg(target_os = "windows")]
     fn test_path_to_uri() {
+        #[cfg(target_os = "windows")]
         let test_folder = Path::new("C:\\tmp\\path_to_uri");
+
+        #[cfg(not(target_os = "windows"))]
+        let test_folder = Path::new("/tmp/path_to_uri");
+
         std::fs::create_dir_all(test_folder).expect("Unable to create test dir");
 
         let test_path = test_folder.join("test.txt");
         let uri = path_to_uri(test_path.to_path_buf());
 
+        #[cfg(target_os = "windows")]
         assert_eq!(uri, "file://localhost/C%3A/tmp/path_to_uri/test.txt");
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(uri, "file://localhost/tmp/path_to_uri/test.txt");
+
         let url = Url::parse(&uri).unwrap();
         let file_path = url.to_file_path().unwrap();
         assert_eq!(file_path, test_path);
+
+        if test_folder.exists() {
+            std::fs::remove_dir_all(test_folder).expect("Unable to clean up test folder");
+        }
     }
 }

--- a/crates/spyglass-plugin/src/utils.rs
+++ b/crates/spyglass-plugin/src/utils.rs
@@ -3,20 +3,39 @@ use url::Url;
 
 // Create a file URI
 pub fn path_to_uri(path: PathBuf) -> String {
-    let path_str = path.to_str().expect("Unable to convert path to string");
-
+    let path_str = path.display().to_string();
     // Eventually this will be away to keep track of multiple devices and searching across
-    // them. Might make sense to generate a UUID and assign to this computer(?) hostname
-    // can be changed by the user.
-    let host = if let Ok(hname) = std::env::var("HOST_NAME") {
-        hname
-    } else {
-        "home.local".into()
-    };
+    // them.
+    let host = "localhost";
 
     let mut new_url = Url::parse("file://").expect("Base URI");
-    let _ = new_url.set_host(Some(&host));
+    let _ = new_url.set_host(Some(host));
     // Fixes issues handling windows drive letters
-    new_url.set_path(&path_str.replace(':', "%3A"));
+    let path_str = path_str.replace(':', "%3A");
+    // Fixes an issue where DirEntry adds too many escapes.
+    let path_str = path_str.replace("\\\\", "\\");
+    new_url.set_path(&path_str);
     new_url.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::path_to_uri;
+    use std::path::Path;
+    use url::Url;
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_path_to_uri() {
+        let test_folder = Path::new("C:\\tmp\\path_to_uri");
+        std::fs::create_dir_all(test_folder).expect("Unable to create test dir");
+
+        let test_path = test_folder.join("test.txt");
+        let uri = path_to_uri(test_path.to_path_buf());
+
+        assert_eq!(uri, "file://localhost/C%3A/tmp/path_to_uri/test.txt");
+        let url = Url::parse(&uri).unwrap();
+        let file_path = url.to_file_path().unwrap();
+        assert_eq!(file_path, test_path);
+    }
 }

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -12,7 +12,6 @@ use url::{Host, Url};
 
 use entities::models::{crawl_queue, fetch_history, tag};
 use entities::sea_orm::prelude::*;
-use shared::url_to_file_path;
 
 use crate::connection::load_connection;
 use crate::crawler::bootstrap::create_archive_url;
@@ -340,24 +339,9 @@ impl Crawler {
         url: &Url,
     ) -> Result<CrawlResult, CrawlError> {
         // Attempt to convert from the URL to a file path
-        #[allow(unused_assignments)]
-        let mut url_path = url
-            .to_file_path()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|_| url.path().to_string());
+        let file_path = url.to_file_path().expect("Invalid file URL");
 
-        #[cfg(not(target_os = "windows"))]
-        {
-            url_path = url_to_file_path(&url_path, false);
-        }
-
-        // Fixes issues handling Windows drive paths
-        #[cfg(target_os = "windows")]
-        {
-            url_path = url_to_file_path(url.path(), true);
-        }
-
-        let path = Path::new(&url_path);
+        let path = Path::new(&file_path);
         // Is this a file and does this exist?
         if !path.exists() || !path.is_file() {
             return Err(CrawlError::NotFound);
@@ -682,5 +666,30 @@ mod test {
 
         let res = determine_canonical(&a, &b);
         assert_eq!(res, "https://en.wikipedia.org/");
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "windows")]
+    async fn test_file_fetch() {
+        let crawler = Crawler::new();
+
+        let db = setup_test_db().await;
+        let state = AppState::builder().with_db(db).build();
+
+        // Should skip this URL
+        let url =
+            Url::parse("file://localhost/C%3A/Users/a5huynh/Documents/Projects/Rust%20Stuff/book/2018-edition/src/appendix-00.md").unwrap();
+        let query = crawl_queue::ActiveModel {
+            domain: Set("localhost".to_string()),
+            url: Set(url.to_string()),
+            crawl_type: Set(crawl_queue::CrawlType::Bootstrap),
+            ..Default::default()
+        };
+        let model = query.insert(&state.db).await.unwrap();
+
+        // Add resource rule to stop the crawl above
+        let res = crawler.fetch_by_job(&state, model.id, true).await;
+        dbg!(&res);
+        assert!(res.is_ok());
     }
 }

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -684,8 +684,7 @@ mod test {
         std::fs::create_dir_all(test_folder).expect("Unable to create test dir");
 
         let test_path = test_folder.join("test.txt");
-        std::fs::write(test_path.clone(), "test_content")
-            .expect("Unable to write test file");
+        std::fs::write(test_path.clone(), "test_content").expect("Unable to write test file");
 
         let uri = path_to_uri(test_path.to_path_buf());
         let url = Url::parse(&uri).unwrap();

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -211,7 +211,9 @@ async fn handle_walk_and_enqueue(
     path: PathBuf,
     supported_exts: &HashSet<String>,
 ) -> WalkStats {
-    let walker = WalkBuilder::new(path).standard_filters(true).build();
+    let walker = WalkBuilder::new(path.clone())
+        .standard_filters(true)
+        .build();
     let enqueue_settings = EnqueueSettings {
         force_allow: true,
         ..Default::default()
@@ -231,7 +233,7 @@ async fn handle_walk_and_enqueue(
 
             if let Some(ext) = ext {
                 if supported_exts.contains(ext) {
-                    to_enqueue.push(path_to_uri(entry.path().to_path_buf()));
+                    to_enqueue.push(path_to_uri(entry.into_path()));
                     stats.files += 1;
                 } else {
                     stats.skipped += 1;

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -98,7 +98,10 @@ pub async fn handle_fetch(state: AppState, task: CrawlTask) -> FetchResult {
             // Add / update search index w/ crawl result.
             if let Some(content) = crawl_result.content {
                 let url = Url::parse(&crawl_result.url).expect("Invalid crawl URL");
-                let url_host = url.host_str().expect("Invalid URL host");
+                let url_host = match url.scheme() {
+                    "file" => "localhost",
+                    _ => url.host_str().expect("Invalid URL host"),
+                };
 
                 let existing = indexed_document::Entity::find()
                     .filter(indexed_document::Column::Url.eq(url.as_str()))


### PR DESCRIPTION
- Works around the weird behavior from `DirEntry` on Windows, escapes the file path twice.
- Change hostname used for `file://` urls to `localhost` for consistency.
- Closes #224, selecting a local file in the search results will open the file using the default app (if any).