### PR TITLE
bugfix: only allow a single account per connection

### DIFF
--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -15,6 +15,7 @@ mod m20221101_000001_add_open_url_col;
 mod m20221107_000001_recreate_connection_table;
 mod m20221109_add_tags_table;
 mod m20221115_000001_local_file_pathfix;
+mod m20221116_000001_add_connection_constraint;
 
 mod utils;
 
@@ -36,6 +37,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221107_000001_recreate_connection_table::Migration),
             Box::new(m20221109_add_tags_table::Migration),
             Box::new(m20221115_000001_local_file_pathfix::Migration),
+            Box::new(m20221116_000001_add_connection_constraint::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20221116_000001_add_connection_constraint.rs
+++ b/crates/migrations/src/m20221116_000001_add_connection_constraint.rs
@@ -1,0 +1,32 @@
+use crate::sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20221116_000001_add_connection_constraint"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create index on (api_id, account). Should only every be one instance of a
+        // an account per service.
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                manager.get_database_backend(),
+                "CREATE UNIQUE INDEX `idx-connections-api-id-account` ON `connections` (`api_id`, `account`);"
+                    .to_string(),
+            ))
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -109,10 +109,12 @@ pub async fn authorize_connection(state: AppState, api_id: String) -> Result<(),
                         Ok(_) => {
                             log::debug!("saved connection {} for {}", user.email.clone(), api_id);
                             let _ = state
-                                .schedule_work(ManagerCommand::Collect(CollectTask::ConnectionSync {
-                                    api_id,
-                                    account: user.email,
-                                }))
+                                .schedule_work(ManagerCommand::Collect(
+                                    CollectTask::ConnectionSync {
+                                        api_id,
+                                        account: user.email,
+                                    },
+                                ))
                                 .await;
                         }
                         Err(err) => log::error!("Unable to save connection: {}", err.to_string()),

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -105,13 +105,18 @@ pub async fn authorize_connection(state: AppState, api_id: String) -> Result<(),
                         auth.scopes,
                     );
                     let res = new_conn.insert(&state.db).await;
-                    log::debug!("saved connection: {:?}", res);
-                    let _ = state
-                        .schedule_work(ManagerCommand::Collect(CollectTask::ConnectionSync {
-                            api_id,
-                            account: user.email,
-                        }))
-                        .await;
+                    match res {
+                        Ok(_) => {
+                            log::debug!("saved connection {} for {}", user.email.clone(), api_id);
+                            let _ = state
+                                .schedule_work(ManagerCommand::Collect(CollectTask::ConnectionSync {
+                                    api_id,
+                                    account: user.email,
+                                }))
+                                .await;
+                        }
+                        Err(err) => log::error!("Unable to save connection: {}", err.to_string()),
+                    }
                 }
                 Err(err) => log::error!("unable to exchange token: {}", err),
             }


### PR DESCRIPTION
- add a constraint to the db to only allow one unique `(account, api_id)` combo