### PR TITLE
bugfix: sea-orm update caused `Queued` to be quoted inside db

### DIFF
--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -137,10 +137,7 @@ pub async fn queue_stats(
 
 pub async fn reset_processing(db: &DatabaseConnection) -> anyhow::Result<()> {
     Entity::update_many()
-        .col_expr(
-            Column::Status,
-            sea_query::Expr::value(CrawlStatus::Queued)
-        )
+        .col_expr(Column::Status, sea_query::Expr::value(CrawlStatus::Queued))
         .filter(Column::Status.eq(CrawlStatus::Processing))
         .exec(db)
         .await?;

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -139,9 +139,7 @@ pub async fn reset_processing(db: &DatabaseConnection) -> anyhow::Result<()> {
     Entity::update_many()
         .col_expr(
             Column::Status,
-            sea_query::Expr::value(sea_query::Value::String(Some(Box::new(
-                CrawlStatus::Queued.to_string(),
-            )))),
+            sea_query::Expr::value(CrawlStatus::Queued)
         )
         .filter(Column::Status.eq(CrawlStatus::Processing))
         .exec(db)

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -16,6 +16,7 @@ mod m20221107_000001_recreate_connection_table;
 mod m20221109_add_tags_table;
 mod m20221115_000001_local_file_pathfix;
 mod m20221116_000001_add_connection_constraint;
+mod m20221118_000001_fix_queued_enum;
 
 mod utils;
 
@@ -38,6 +39,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221109_add_tags_table::Migration),
             Box::new(m20221115_000001_local_file_pathfix::Migration),
             Box::new(m20221116_000001_add_connection_constraint::Migration),
+            Box::new(m20221118_000001_fix_queued_enum::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20221118_000001_fix_queued_enum.rs
+++ b/crates/migrations/src/m20221118_000001_fix_queued_enum.rs
@@ -1,0 +1,31 @@
+use crate::sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20221116_000001_fix_queued_enum"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create index on (api_id, account). Should only every be one instance of a
+        // an account per service.
+        manager
+            .get_connection()
+            .execute(Statement::from_string(
+                manager.get_database_backend(),
+                "UPDATE crawl_queue SET status = 'Queued' where status = '''Queued'''".to_string(),
+            ))
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -341,9 +341,7 @@ pub async fn recrawl_domain(state: AppState, domain: String) -> Result<(), Error
     let res = crawl_queue::Entity::update_many()
         .col_expr(
             crawl_queue::Column::Status,
-            sea_query::Expr::value(sea_query::Value::String(Some(Box::new(
-                CrawlStatus::Queued.to_string(),
-            )))),
+            sea_query::Expr::value(CrawlStatus::Queued)
         )
         .filter(crawl_queue::Column::Domain.eq(domain.clone()))
         .exec(db)

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -341,7 +341,7 @@ pub async fn recrawl_domain(state: AppState, domain: String) -> Result<(), Error
     let res = crawl_queue::Entity::update_many()
         .col_expr(
             crawl_queue::Column::Status,
-            sea_query::Expr::value(CrawlStatus::Queued)
+            sea_query::Expr::value(CrawlStatus::Queued),
         )
         .filter(crawl_queue::Column::Domain.eq(domain.clone()))
         .exec(db)


### PR DESCRIPTION
- update enum usage in code
- add migration to fix existing dbs