### PR TITLE
bugfix: add bootstrap shutdown listener

### DIFF
--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -173,28 +173,28 @@ async fn start_backend(state: &mut AppState, config: &Config) {
         state.clone(),
         worker_cmd_tx,
         manager_cmd_tx.clone(),
-        manager_cmd_rx
+        manager_cmd_rx,
     ));
 
     // Crawlers
     let worker_handle = tokio::spawn(task::worker_task(
         state.clone(),
         worker_cmd_rx,
-        pause_tx.subscribe()
+        pause_tx.subscribe(),
     ));
 
     // Check lenses for updates & add any bootstrapped URLs to crawler.
     let lens_watcher_handle = tokio::spawn(task::lens_watcher(
         state.clone(),
         config.clone(),
-        pause_tx.subscribe()
+        pause_tx.subscribe(),
     ));
 
     // Loads and processes pipeline commands
     let _pipeline_handler = tokio::spawn(pipeline::initialize_pipelines(
         state.clone(),
         config.clone(),
-        pipeline_cmd_rx
+        pipeline_cmd_rx,
     ));
 
     // Plugin server
@@ -202,7 +202,7 @@ async fn start_backend(state: &mut AppState, config: &Config) {
         state.clone(),
         config.clone(),
         plugin_cmd_tx.clone(),
-        plugin_cmd_rx
+        plugin_cmd_rx,
     ));
 
     // API server
@@ -212,13 +212,19 @@ async fn start_backend(state: &mut AppState, config: &Config) {
     match signal::ctrl_c().await {
         Ok(()) => {
             log::warn!("Shutdown request received");
-            state.shutdown_cmd_tx.lock().await
+            state
+                .shutdown_cmd_tx
+                .lock()
+                .await
                 .send(AppShutdown::Now)
                 .expect("Unable to send AppShutdown cmd");
         }
         Err(err) => {
             log::error!("Unable to listen for shutdown signal: {}", err);
-            state.shutdown_cmd_tx.lock().await
+            state
+                .shutdown_cmd_tx
+                .lock()
+                .await
                 .send(AppShutdown::Now)
                 .expect("Unable to send AppShutdown cmd");
         }

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -2,11 +2,11 @@ use crate::pipeline::collector::DefaultCollector;
 use crate::pipeline::PipelineContext;
 use crate::search::Searcher;
 use crate::state::AppState;
-use crate::task::{AppShutdown, CrawlTask};
+use crate::task::CrawlTask;
 
 use entities::models::{crawl_queue, indexed_document};
 use shared::config::{Config, LensConfig, PipelineConfiguration};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 use super::parser::DefaultParser;
 use super::PipelineCommand;
@@ -24,8 +24,8 @@ pub async fn pipeline_loop(
     pipeline: String,
     _pipeline_cfg: PipelineConfiguration,
     mut pipeline_queue: mpsc::Receiver<PipelineCommand>,
-    mut shutdown_rx: broadcast::Receiver<AppShutdown>,
 ) {
+    let mut shutdown_rx = state.shutdown_cmd_tx.lock().await.subscribe();
     log::debug!("Default Pipeline Loop Started for Pipeline: {:?}", pipeline);
 
     let collector = DefaultCollector::new();

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -80,7 +80,7 @@ pub async fn initialize_pipelines(
                 config.clone(),
                 pipeline.clone(),
                 pipelines.get(&pipeline).unwrap().clone(),
-                pipeline_cmd_rx
+                pipeline_cmd_rx,
             ));
         } else {
             log::error!(

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -4,7 +4,6 @@ pub mod parser;
 
 use crate::search::lens;
 use crate::state::AppState;
-use crate::task::AppShutdown;
 use crate::task::CrawlTask;
 use entities::models::crawl_queue;
 use shared::config::Config;
@@ -12,7 +11,7 @@ use shared::config::PipelineConfiguration;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 // The pipeline context is a context object that is passed between
 // all stages of the pipeline. This allows later stages in the pipeline
@@ -49,10 +48,8 @@ pub async fn initialize_pipelines(
     app_state: AppState,
     config: Config,
     mut general_pipeline_queue: mpsc::Receiver<PipelineCommand>,
-    shutdown_tx: broadcast::Sender<AppShutdown>,
 ) {
-    let mut shutdown_rx = shutdown_tx.subscribe();
-
+    let mut shutdown_rx = app_state.shutdown_cmd_tx.lock().await.subscribe();
     // Yes probably should do some error handling, but not really needed. No pipelines
     // just means not tasks to send.
     let _ = lens::read_lenses(&app_state, &config).await;
@@ -83,8 +80,7 @@ pub async fn initialize_pipelines(
                 config.clone(),
                 pipeline.clone(),
                 pipelines.get(&pipeline).unwrap().clone(),
-                pipeline_cmd_rx,
-                shutdown_tx.subscribe(),
+                pipeline_cmd_rx
             ));
         } else {
             log::error!(

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -163,7 +163,7 @@ pub async fn plugin_event_loop(
     state: AppState,
     config: Config,
     cmd_writer: mpsc::Sender<PluginCommand>,
-    mut cmd_queue: mpsc::Receiver<PluginCommand>
+    mut cmd_queue: mpsc::Receiver<PluginCommand>,
 ) {
     log::info!("🔌 plugin event loop started");
     // Initial load, send some basic configuration to the plugins

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -10,7 +10,7 @@ use notify::{event::ModifyKind, EventKind, RecursiveMode, Watcher};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use spyglass_plugin::SearchFilter;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use wasmer::{Instance, Module, Store, WasmerEnv};
 use wasmer_wasi::{Pipe, WasiEnv, WasiState};
@@ -21,7 +21,6 @@ use shared::plugin::{PluginConfig, PluginType};
 use spyglass_plugin::{consts::env, PluginEvent, PluginSubscription};
 
 use crate::state::AppState;
-use crate::task::AppShutdown;
 
 mod exports;
 
@@ -164,8 +163,7 @@ pub async fn plugin_event_loop(
     state: AppState,
     config: Config,
     cmd_writer: mpsc::Sender<PluginCommand>,
-    mut cmd_queue: mpsc::Receiver<PluginCommand>,
-    mut shutdown_rx: broadcast::Receiver<AppShutdown>,
+    mut cmd_queue: mpsc::Receiver<PluginCommand>
 ) {
     log::info!("🔌 plugin event loop started");
     // Initial load, send some basic configuration to the plugins
@@ -188,6 +186,8 @@ pub async fn plugin_event_loop(
 
     // Subscribe plugins check for updates every 10 minutes
     let mut interval = tokio::time::interval(Duration::from_secs(10 * 60));
+    let mut shutdown_rx = state.shutdown_cmd_tx.lock().await.subscribe();
+
     loop {
         // Wait for next command / handle shutdown responses
         let next_cmd = tokio::select! {

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -250,7 +250,7 @@ pub async fn worker_task(
 pub async fn lens_watcher(
     state: AppState,
     config: Config,
-    mut pause_rx: broadcast::Receiver<AppPause>
+    mut pause_rx: broadcast::Receiver<AppPause>,
 ) {
     log::info!("👀 lens watcher started");
 

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -25,7 +25,7 @@ pub async fn handle_bootstrap(
     if let Ok(false) = bootstrap_queue::has_seed_url(db, seed_url).await {
         log::info!("bootstrapping {}", seed_url);
 
-        match bootstrap::bootstrap(lens, db, user_settings, seed_url, pipeline).await {
+        match bootstrap::bootstrap(state, lens, db, user_settings, seed_url, pipeline).await {
             Err(e) => {
                 log::error!("bootstrap {}", e);
                 return false;


### PR DESCRIPTION
Fixes an issue where during long bootstrapping events the backend can continue existing after shutdown is requested.