### PR TITLE
feature: regular recrawls & dequeue logic cleanup

### DIFF
--- a/crates/client/src/components/btn.rs
+++ b/crates/client/src/components/btn.rs
@@ -12,7 +12,10 @@ pub struct DeleteButtonProps {
 pub fn delete_btn(props: &DeleteButtonProps) -> Html {
     let onclick = {
         let doc_id = props.doc_id.clone();
-        Callback::from(move |_| {
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            e.stop_immediate_propagation();
+
             let doc_id = doc_id.clone();
             spawn_local(async move {
                 let _ = crate::delete_doc(doc_id.clone()).await;

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -954,12 +954,12 @@ mod test {
     async fn test_dequeue_recrawl() {
         let settings = UserSettings::default();
         let db = setup_test_db().await;
-        let url = "https://oldschool.runescape.wiki/";
+        let url = "file:///tmp/test.txt";
 
         let one_day_ago = chrono::Utc::now() - chrono::Duration::days(1);
         let model = crawl_queue::ActiveModel {
             crawl_type: Set(CrawlType::Normal),
-            domain: Set("oldschool.runescape.wiki".to_string()),
+            domain: Set("localhost".to_string()),
             status: Set(crawl_queue::CrawlStatus::Completed),
             url: Set(url.to_string()),
             created_at: Set(one_day_ago.clone()),

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -323,7 +323,7 @@ pub async fn dequeue_recrawl(
     // TODO: Right now only recrawl local files.
     let task = Entity::find()
         .filter(Column::Status.eq(CrawlStatus::Completed))
-        .filter(Column::Domain.eq("localhost"))
+        .filter(Column::Url.starts_with("file://"))
         .order_by_asc(Column::UpdatedAt)
         .one(db)
         .await?;

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -320,9 +320,10 @@ pub async fn dequeue_recrawl(
         }
     }
 
-    // Prioritize any bootstrapping tasks first.
+    // TODO: Right now only recrawl local files.
     let task = Entity::find()
         .filter(Column::Status.eq(CrawlStatus::Completed))
+        .filter(Column::Domain.eq("localhost"))
         .order_by_asc(Column::UpdatedAt)
         .one(db)
         .await?;

--- a/crates/entities/src/models/sql/dequeue.sqlx
+++ b/crates/entities/src/models/sql/dequeue.sqlx
@@ -1,3 +1,4 @@
+WITH
 indexed AS (
     SELECT
         domain,
@@ -16,8 +17,6 @@ inflight AS (
 SELECT
     cq.*
 FROM crawl_queue cq
-LEFT JOIN p_domain ON cq.domain like p_domain.domain
-LEFT JOIN p_prefix ON cq.url like p_prefix.prefix
 LEFT JOIN indexed ON indexed.domain = cq.domain
 LEFT JOIN inflight ON inflight.domain = cq.domain
 WHERE
@@ -25,6 +24,4 @@ WHERE
     COALESCE(inflight.count, 0) < ? AND
     status = "Queued"
 ORDER BY
-    p_prefix.priority DESC,
-    p_domain.priority DESC,
     cq.updated_at ASC

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -360,7 +360,10 @@ impl Crawler {
         url: &Url,
     ) -> Result<CrawlResult, CrawlError> {
         // Attempt to convert from the URL to a file path
-        let file_path = url.to_file_path().expect("Invalid file URL");
+        let file_path = match url.to_file_path() {
+            Ok(path) => path,
+            Err(_) => return Err(CrawlError::NotFound),
+        };
 
         let path = Path::new(&file_path);
         // Is this a file and does this exist?

--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -106,7 +106,7 @@ pub async fn check_resource_rules(db: &DatabaseConnection, client: &HTTPClient, 
         .await
         .expect("Unable to add resource rules");
 
-    if rules.is_empty() {
+    if rules.is_empty() && domain != "localhost" {
         log::info!("No rules found for <{}>, fetching robot.txt", domain);
         let mut robots_url = url.clone();
         robots_url.set_path("/robots.txt");

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -83,13 +83,7 @@ async fn start_crawl(
                 Ok(parse_result) => {
                     let crawl_result = parse_result.content;
                     // Update job status
-                    let _ = crawl_queue::mark_done(
-                        &state.db,
-                        task.id,
-                        crawl_queue::CrawlStatus::Completed,
-                        None,
-                    )
-                    .await;
+                    let _ = crawl_queue::mark_done(&state.db, task.id, None).await;
 
                     // Add all valid, non-duplicate, non-indexed links found to crawl queue
                     let to_enqueue: Vec<String> = crawl_result.links.into_iter().collect();
@@ -177,22 +171,14 @@ async fn start_crawl(
                 Err(err) => {
                     log::info!("Unable to crawl id: {} - {:?}", task.id, err);
                     // mark crawl as failed
-                    let _ = crawl_queue::mark_done(
-                        &state.db,
-                        task.id,
-                        crawl_queue::CrawlStatus::Failed,
-                        None,
-                    )
-                    .await;
+                    crawl_queue::mark_failed(&state.db, task.id, false).await;
                 }
             }
         }
         Err(err) => {
             log::info!("Unable to crawl id: {} - {:?}", task.id, err);
             // mark crawl as failed
-            let _ =
-                crawl_queue::mark_done(&state.db, task.id, crawl_queue::CrawlStatus::Failed, None)
-                    .await;
+            crawl_queue::mark_failed(&state.db, task.id, false).await;
         }
     }
 }

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -136,8 +136,7 @@ pub async fn initialize_pipelines(
 // Helper function used to set any crawl failures with the status of failed.
 pub async fn fail_crawl_cmd(state: &AppState, task_uid: i64) {
     // mark crawl as failed
-    let _ =
-        crawl_queue::mark_done(&state.db, task_uid, crawl_queue::CrawlStatus::Failed, None).await;
+    crawl_queue::mark_failed(&state.db, task_uid, false).await;
 }
 
 /// Read pipelines into the AppState

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -44,13 +44,17 @@ pub enum ManagerCommand {
 /// Send tasks to the worker
 #[derive(Clone, Debug)]
 pub enum WorkerCommand {
+    /// Enqueues the URLs needed to start crawl.
     Collect(CollectTask),
-    // Commit any changes that have been made to the index.
+    /// Commit any changes that have been made to the index.
     CommitIndex,
-    // Fetch, parses, & indexes a URI
-    // TODO: Split this up so that this work can be spread out.
+    /// Fetch, parses, & indexes a URI
+    /// TODO: Split this up so that this work can be spread out.
     Crawl { id: i64 },
-    // Applies tag information to an URI
+    /// Refetches, parses, & indexes a URI
+    /// If the URI no longer exists (file moved, 404 etc), delete from index.
+    Recrawl { id: i64 },
+    /// Applies tag information to an URI
     Tag,
 }
 

--- a/crates/spyglass/src/task/manager.rs
+++ b/crates/spyglass/src/task/manager.rs
@@ -108,8 +108,8 @@ mod test {
         // Insert dummy job
         let one_day_ago = chrono::Utc::now() - chrono::Duration::days(1);
         let task = crawl_queue::ActiveModel {
-            url: Set("https://example.com".to_owned()),
-            domain: Set("example.com".to_owned()),
+            url: Set("file:///tmp/test.txt".to_owned()),
+            domain: Set("localhost".to_owned()),
             crawl_type: Set(CrawlType::Normal),
             status: Set(CrawlStatus::Completed),
             created_at: Set(one_day_ago.clone()),
@@ -120,8 +120,8 @@ mod test {
 
         let two_day_ago = chrono::Utc::now() - chrono::Duration::days(2);
         let task = crawl_queue::ActiveModel {
-            url: Set("https://example.com/this_one".to_owned()),
-            domain: Set("example.com".to_owned()),
+            url: Set("file:///tmp/this_one.txt".to_owned()),
+            domain: Set("localhost".to_owned()),
             crawl_type: Set(CrawlType::Normal),
             status: Set(CrawlStatus::Completed),
             created_at: Set(two_day_ago.clone()),

--- a/crates/spyglass/src/task/manager.rs
+++ b/crates/spyglass/src/task/manager.rs
@@ -8,6 +8,7 @@ use crate::state::AppState;
 // Check for new jobs in the crawl queue and add them to the worker queue.
 #[tracing::instrument(skip(state, queue))]
 pub async fn check_for_jobs(state: &AppState, queue: &mpsc::Sender<WorkerCommand>) -> bool {
+    // Do we have any crawl tasks?
     match crawl_queue::dequeue(&state.db, state.user_settings.clone()).await {
         Ok(Some(task)) => {
             match &task.pipeline {
@@ -22,7 +23,7 @@ pub async fn check_for_jobs(state: &AppState, queue: &mpsc::Sender<WorkerCommand
                             log::error!("Unable to send crawl task to pipeline {:?}", err);
                         }
                     }
-                    true
+                    return true;
                 }
                 None => {
                     // Send to worker
@@ -30,17 +31,103 @@ pub async fn check_for_jobs(state: &AppState, queue: &mpsc::Sender<WorkerCommand
                     if queue.send(cmd).await.is_err() {
                         log::error!("unable to send command to worker");
                     }
-                    true
+                    return true;
                 }
             }
         }
-        Ok(None) => {
-            // nothing to do!
-            false
-        }
         Err(err) => {
             log::error!("Unable to dequeue jobs: {}", err.to_string());
-            false
+            return false;
         }
+        _ => {}
+    }
+
+    // No crawl tasks, check for recrawl tasks
+    match crawl_queue::dequeue_recrawl(&state.db, &state.user_settings).await {
+        Ok(Some(task)) => {
+            // Send to worker
+            let cmd = WorkerCommand::Recrawl { id: task.id };
+            if queue.send(cmd).await.is_err() {
+                log::error!("unable to send command to worker");
+            }
+            return true;
+        }
+        Err(err) => {
+            log::error!("Unable to dequeue_recrawl jobs: {}", err.to_string());
+            return false;
+        }
+        _ => {}
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use tokio::sync::mpsc;
+
+    use super::check_for_jobs;
+    use crate::{state::AppState, task::WorkerCommand};
+    use entities::models::crawl_queue::{self, CrawlStatus, CrawlType};
+    use entities::sea_orm::{ActiveModelTrait, Set};
+    use entities::test::setup_test_db;
+
+    #[tokio::test]
+    async fn test_check_for_jobs() {
+        let db = setup_test_db().await;
+        let state = AppState::builder().with_db(db.clone()).build();
+
+        // Insert dummy job
+        let task = crawl_queue::ActiveModel {
+            url: Set("https://example.com".to_owned()),
+            domain: Set("example.com".to_owned()),
+            crawl_type: Set(CrawlType::Normal),
+            status: Set(CrawlStatus::Queued),
+            ..Default::default()
+        };
+        let mut saved = task.save(&db).await.expect("Unable to save dummy task");
+
+        let (sender, mut recv) = mpsc::channel(10);
+        let has_job = check_for_jobs(&state, &sender).await;
+        assert!(has_job);
+
+        let message = recv.recv().await.expect("no WorkerCommand in channel");
+        assert_eq!(
+            message,
+            WorkerCommand::Crawl {
+                id: saved.id.take().unwrap_or_default()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_for_jobs_recrawl() {
+        let db = setup_test_db().await;
+        let state = AppState::builder().with_db(db.clone()).build();
+
+        // Insert dummy job
+        let one_day_ago = chrono::Utc::now() - chrono::Duration::days(1);
+        let task = crawl_queue::ActiveModel {
+            url: Set("https://example.com".to_owned()),
+            domain: Set("example.com".to_owned()),
+            crawl_type: Set(CrawlType::Normal),
+            status: Set(CrawlStatus::Completed),
+            created_at: Set(one_day_ago.clone()),
+            updated_at: Set(one_day_ago),
+            ..Default::default()
+        };
+        let mut saved = task.save(&db).await.expect("Unable to save dummy task");
+
+        let (sender, mut recv) = mpsc::channel(10);
+        let has_job = check_for_jobs(&state, &sender).await;
+        assert!(has_job);
+
+        let message = recv.recv().await.expect("no WorkerCommand in channel");
+        assert_eq!(
+            message,
+            WorkerCommand::Recrawl {
+                id: saved.id.take().unwrap_or_default()
+            }
+        );
     }
 }

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -78,18 +78,19 @@ pub async fn process_crawl(
     // Update URL in crawl_task to match the canonical URL extracted in the crawl result.
     if task.url != crawl_result.url {
         log::debug!("Updating task URL {} -> {}", task.url, crawl_result.url);
-        task = match crawl_queue::update_or_remove_task(&state.db, task.id, &crawl_result.url).await {
+        task = match crawl_queue::update_or_remove_task(&state.db, task.id, &crawl_result.url).await
+        {
             Ok(updated) => {
                 if updated.id != task.id {
                     log::debug!("Removed {}, duplicate canonical URL found", task.id);
                 }
 
                 updated
-            },
+            }
             Err(err) => {
                 log::error!("Unable to update task URL: {}", err);
                 task
-            },
+            }
         }
     }
 
@@ -218,11 +219,11 @@ pub async fn handle_fetch(state: AppState, task: CrawlTask) -> FetchResult {
             Ok(res) => {
                 log::debug!("Crawled task id: {} - {:?}", task.id, res);
                 res
-            },
+            }
             Err(err) => {
                 log::warn!("Unable to crawl id: {} - {:?}", task.id, err);
                 FetchResult::Error(err)
-            },
+            }
         },
         Err(err) => {
             log::warn!("Unable to crawl id: {} - {:?}", task.id, err);


### PR DESCRIPTION
- Spyglass will recrawl files & check for updates (or deletions) on a regular interval. ~once a day for now.
- Cleaned up logic around dequeuing jobs. FIFO: prioritizing bootstraps -> normal crawls -> recrawls.

Crawler changes
- keep track of the canonical URL and removes any duplicate tasks.
- only retry Timeout errors, everything else is marked as failed and we move on.
