### PR TITLE
tweak(windows): add borders to search bar initial inner_size

### DIFF
--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -129,7 +129,7 @@ impl Component for SearchPage {
         // Listen to onblur events so we can hide the search bar
         if let Some(wind) = window() {
             let link_clone = link.clone();
-            let on_blur = EventListener::new(&wind, "blur", move |_event| {
+            let on_blur = EventListener::new(&wind, "blur", move |_| {
                 link_clone.send_message(Msg::Blur);
             });
 

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -153,6 +153,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 log::error!("Unable to copy default plugins: {}", e);
             }
 
+            let default_height = if cfg!(target_os = "windows") {
+                98.0
+            } else {
+                96.0
+            };
+
             let window = WindowBuilder::new(
                 app,
                 constants::SEARCH_WIN_NAME,
@@ -161,7 +167,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .decorations(false)
                 .transparent(true)
                 .disable_file_drop_handler()
-                .inner_size(640.0, 96.0)
+                .inner_size(640.0, default_height)
                 .build()
                 .expect("Unable to create searchbar window");
             // Center on launch.


### PR DESCRIPTION
Windows: prevents a scrollbar from showing up when the app is first started