### PR TITLE
tweak: speed up tag migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,6 +3218,7 @@ dependencies = [
 name = "migration"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "entities",
  "log",
  "rayon",

--- a/crates/entities/src/models/crawl_tag.rs
+++ b/crates/entities/src/models/crawl_tag.rs
@@ -1,0 +1,49 @@
+use sea_orm::entity::prelude::*;
+use sea_orm::Set;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Eq)]
+#[sea_orm(table_name = "crawl_tag")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub crawl_queue_id: i64,
+    pub tag_id: i64,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter)]
+pub enum Relation {
+    CrawlQueue,
+    Tag,
+}
+
+impl RelationTrait for Relation {
+    fn def(&self) -> RelationDef {
+        match self {
+            Self::CrawlQueue => Entity::belongs_to(super::crawl_queue::Entity)
+                .from(Column::CrawlQueueId)
+                .to(super::crawl_queue::Column::Id)
+                .into(),
+            Self::Tag => Entity::belongs_to(super::tag::Entity)
+                .from(Column::TagId)
+                .to(super::tag::Column::Id)
+                .into(),
+        }
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {
+    // Triggered before insert / update
+    fn before_save(mut self, insert: bool) -> Result<Self, DbErr> {
+        if insert {
+            self.created_at = Set(chrono::Utc::now());
+            self.updated_at = Set(chrono::Utc::now());
+        } else {
+            self.updated_at = Set(chrono::Utc::now());
+        }
+
+        Ok(self)
+    }
+}

--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -1,6 +1,6 @@
 use crate::models::{document_tag, tag};
 use sea_orm::entity::prelude::*;
-use sea_orm::{FromQueryResult, InsertResult, QuerySelect, Set};
+use sea_orm::{ConnectionTrait, FromQueryResult, InsertResult, QuerySelect, Set};
 
 use super::tag::{get_or_create, TagPair};
 
@@ -67,9 +67,9 @@ impl ActiveModelBehavior for ActiveModel {
 }
 
 impl ActiveModel {
-    pub async fn insert_tags(
+    pub async fn insert_tags<C: ConnectionTrait>(
         &self,
-        db: &DatabaseConnection,
+        db: &C,
         tags: &[TagPair],
     ) -> Result<InsertResult<document_tag::ActiveModel>, DbErr> {
         let mut tag_models: Vec<tag::Model> = Vec::new();

--- a/crates/entities/src/models/mod.rs
+++ b/crates/entities/src/models/mod.rs
@@ -3,6 +3,7 @@ use sea_orm::{ConnectOptions, Database, DatabaseConnection};
 pub mod bootstrap_queue;
 pub mod connection;
 pub mod crawl_queue;
+pub mod crawl_tag;
 pub mod document_tag;
 pub mod fetch_history;
 pub mod indexed_document;

--- a/crates/entities/src/models/tag.rs
+++ b/crates/entities/src/models/tag.rs
@@ -1,5 +1,5 @@
-use sea_orm::entity::prelude::*;
 use sea_orm::Set;
+use sea_orm::{entity::prelude::*, ConnectionTrait};
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, EnumString};
 
@@ -98,11 +98,10 @@ impl Related<super::indexed_document::Entity> for Entity {
     }
 }
 
-pub async fn get_or_create(
-    db: &DatabaseConnection,
-    label: TagType,
-    value: &str,
-) -> Result<Model, DbErr> {
+pub async fn get_or_create<C>(db: &C, label: TagType, value: &str) -> Result<Model, DbErr>
+where
+    C: ConnectionTrait,
+{
     let tag = ActiveModel {
         label: Set(label.clone()),
         value: Set(value.to_string()),

--- a/crates/entities/src/test.rs
+++ b/crates/entities/src/test.rs
@@ -2,8 +2,8 @@ use sea_orm::{sea_query::Index, ConnectionTrait, DatabaseConnection, Schema};
 use shared::config::Config;
 
 use crate::models::{
-    bootstrap_queue, crawl_queue, create_connection, document_tag, fetch_history, indexed_document,
-    lens, link, resource_rule, tag,
+    bootstrap_queue, crawl_queue, crawl_tag, create_connection, document_tag, fetch_history,
+    indexed_document, lens, link, resource_rule, tag,
 };
 
 #[allow(dead_code)]
@@ -94,6 +94,15 @@ async fn setup_schema(db: &DatabaseConnection) -> anyhow::Result<(), sea_orm::Db
 
     db.execute(
         builder.build(
+            schema
+                .create_table_from_entity(crawl_tag::Entity)
+                .if_not_exists(),
+        ),
+    )
+    .await?;
+
+    db.execute(
+        builder.build(
             &Index::create()
                 .unique()
                 .name("idx-tags-label-value")
@@ -113,6 +122,19 @@ async fn setup_schema(db: &DatabaseConnection) -> anyhow::Result<(), sea_orm::Db
                 .table(document_tag::Entity)
                 .col(document_tag::Column::IndexedDocumentId)
                 .col(document_tag::Column::TagId)
+                .to_owned(),
+        ),
+    )
+    .await?;
+
+    db.execute(
+        builder.build(
+            &Index::create()
+                .unique()
+                .name("idx-crawl-tag-doc-id-tag-id")
+                .table(crawl_tag::Entity)
+                .col(crawl_tag::Column::CrawlQueueId)
+                .col(crawl_tag::Column::TagId)
                 .to_owned(),
         ),
     )

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -9,6 +9,7 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 entities = { path = "../entities" }
 log = "0.4"
 rayon = "1.5"

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -20,7 +20,7 @@ mod m20221118_000001_fix_queued_enum;
 mod m20221121_000001_add_data_to_crawl_queue;
 mod m20221123_000001_add_document_tag_constraint;
 mod m20221124_000001_add_tags_for_existing_lenses;
-
+mod m20221210_000001_add_crawl_tags_table;
 mod utils;
 
 pub struct Migrator;
@@ -46,6 +46,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221121_000001_add_data_to_crawl_queue::Migration),
             Box::new(m20221123_000001_add_document_tag_constraint::Migration),
             Box::new(m20221124_000001_add_tags_for_existing_lenses::Migration),
+            Box::new(m20221210_000001_add_crawl_tags_table::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
+++ b/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
@@ -35,13 +35,13 @@ where
     let start_time = Instant::now();
     let tag = vec![(TagType::Lens, name.to_owned())];
     let data = TaskData::new(&tag);
-    crawl_queue::Entity::update_many()
+    let res = crawl_queue::Entity::update_many()
         .col_expr(crawl_queue::Column::Data, Expr::value(data))
         .filter(crawl_queue::Column::Url.contains(url))
         .exec(tx)
         .await?;
     let time_taken = Instant::now() - start_time;
-    log::info!("{}: tagged tasks in {}ms", name, time_taken.as_millis());
+    log::info!("{}: tagged {} tasks in {}ms", name, res.rows_affected, time_taken.as_millis());
 
     // Update existing documents
     let start_time = Instant::now();

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -272,6 +272,7 @@ pub async fn lens_watcher(
     mut pause_rx: broadcast::Receiver<AppPause>,
 ) {
     log::info!("👀 lens watcher started");
+    let mut shutdown_rx = state.shutdown_cmd_tx.lock().await.subscribe();
 
     let mut is_paused = false;
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -292,7 +293,6 @@ pub async fn lens_watcher(
     // Read + load lenses for the first time.
     let _ = read_lenses(&state, &config).await;
     load_lenses(state.clone()).await;
-    let mut shutdown_rx = state.shutdown_cmd_tx.lock().await.subscribe();
 
     loop {
         // Run w/ a select on the shutdown signal otherwise we're stuck in an


### PR DESCRIPTION
- use transactions + update/insert many to speed up tag migration
- break task tags into their own table vs using a JSON column