### PR TITLE
ci: run & check migrations during CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,4 +83,7 @@ jobs:
       with:
         command: fmt
         args: --all --check
-
+    # Run spyglass backend in check mode to validate migrations & other basic startup
+    # procedures.
+    - name: run spyglass checks
+      run: cargo run -p spyglass -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -614,13 +614,28 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.0.21",
+ "clap_lex 0.3.0",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -637,10 +652,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1404,6 +1441,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2339,6 +2397,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,10 +2678,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -3025,6 +3114,12 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "local-file-indexer"
@@ -3473,7 +3568,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -4558,6 +4653,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4704,7 +4813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882af0d4cd3d6cc2f427d14a48e9f468b37c563b405ea486fd314ba18ca334d0"
 dependencies = [
  "chrono",
- "clap",
+ "clap 3.2.23",
  "dotenvy",
  "regex",
  "sea-schema",
@@ -4733,7 +4842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86fe6e594b078712e1e797b951b9b56e55d3cfa04aac8ea76eb4bed7c94c5910"
 dependencies = [
  "async-trait",
- "clap",
+ "clap 3.2.23",
  "dotenvy",
  "sea-orm",
  "sea-orm-cli",
@@ -5367,6 +5476,7 @@ dependencies = [
  "bytes",
  "calamine",
  "chrono",
+ "clap 4.0.32",
  "dashmap",
  "digest 0.10.5",
  "directories",

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -325,7 +325,7 @@ impl Config {
 
     pub fn new() -> Self {
         let prefs_dir = Config::prefs_dir();
-        fs::create_dir_all(&prefs_dir).expect("Unable to create config folder");
+        fs::create_dir_all(prefs_dir).expect("Unable to create config folder");
 
         // Gracefully handle issues loading user settings/lenses
         let user_settings = Self::load_user_settings().unwrap_or_else(|err| {
@@ -340,22 +340,22 @@ impl Config {
         };
 
         let data_dir = config.data_dir();
-        fs::create_dir_all(&data_dir).expect("Unable to create data folder");
+        fs::create_dir_all(data_dir).expect("Unable to create data folder");
 
         let index_dir = config.index_dir();
-        fs::create_dir_all(&index_dir).expect("Unable to create index folder");
+        fs::create_dir_all(index_dir).expect("Unable to create index folder");
 
         let logs_dir = config.logs_dir();
-        fs::create_dir_all(&logs_dir).expect("Unable to create logs folder");
+        fs::create_dir_all(logs_dir).expect("Unable to create logs folder");
 
         let lenses_dir = config.lenses_dir();
-        fs::create_dir_all(&lenses_dir).expect("Unable to create `lenses` folder");
+        fs::create_dir_all(lenses_dir).expect("Unable to create `lenses` folder");
 
         let pipelines_dir = config.pipelines_dir();
-        fs::create_dir_all(&pipelines_dir).expect("Unable to create `pipelines` folder");
+        fs::create_dir_all(pipelines_dir).expect("Unable to create `pipelines` folder");
 
         let plugins_dir = config.plugins_dir();
-        fs::create_dir_all(&plugins_dir).expect("Unable to create `plugin` folder");
+        fs::create_dir_all(plugins_dir).expect("Unable to create `plugin` folder");
 
         config
     }

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 bytes = "1.2.1"
 calamine = "0.19.1"
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4.0.32", features = ["derive"] }
 dashmap = "5.2"
 digest = "0.10"
 directories = "4.0"
@@ -17,13 +18,13 @@ docx =  { git = "https://github.com/spyglass-search/docx-rs", branch = "master"}
 ego-tree = "0.6.2"
 entities = { path = "../entities" }
 futures = "0.3"
+google = { git = "https://github.com/spyglass-search/third-party-apis", rev = "37675fbc7973b2e8ad7b8f1544f9f0f05f0ed1e4" }
 hex = "0.4"
 hostname = "^0.3"
 html5ever = "0.25"
 http = "0.2"
 ignore = "0.4"
 jsonrpsee = { version = "0.15", features = ["http-server"] }
-google = { git = "https://github.com/spyglass-search/third-party-apis", rev = "37675fbc7973b2e8ad7b8f1544f9f0f05f0ed1e4" }
 log = "0.4"
 migration = { path = "../migrations" }
 notify = "5.0.0-pre.16"

--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -41,7 +41,7 @@ pub fn filter_set(rules: &[ParsedRule], allow: bool) -> RegexSet {
         .map(|x| x.regex.clone())
         .collect();
 
-    RegexSet::new(&rules).expect("Invalid regex rules")
+    RegexSet::new(rules).expect("Invalid regex rules")
 }
 
 /// Parse a robots.txt file and return a vector of parsed rules

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -1,4 +1,5 @@
 extern crate notify;
+use clap::Parser;
 use std::io;
 use tokio::signal;
 use tokio::sync::{broadcast, mpsc};
@@ -27,8 +28,17 @@ const SPYGLASS_LEVEL: &str = "spyglass=DEBUG";
 #[cfg(debug_assertions)]
 const LIBSPYGLASS_LEVEL: &str = "libspyglass=DEBUG";
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct CliArgs {
+    /// Run migrations & basic checks.
+    #[arg(short, long)]
+    check: bool,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = Config::new();
+    let args = CliArgs::parse();
 
     #[cfg(not(debug_assertions))]
     let _guard = if config.user_settings.disable_telemetry {
@@ -107,7 +117,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize/Load user preferences
     let mut state = rt.block_on(AppState::new(&config));
-    rt.block_on(start_backend(&mut state, &config));
+    if !args.check {
+        rt.block_on(start_backend(&mut state, &config));
+    }
 
     Ok(())
 }

--- a/crates/spyglass/src/plugin/exports.rs
+++ b/crates/spyglass/src/plugin/exports.rs
@@ -166,7 +166,7 @@ fn handle_sync_file(env: &PluginEnv, dst: &str, src: &str) {
     if let Some(file_name) = src.file_name() {
         let dst = env.data_dir.join(dst).join(file_name);
         // Attempt to copy file into plugin data directory
-        if let Err(e) = std::fs::copy(src, &dst) {
+        if let Err(e) = std::fs::copy(src, dst) {
             log::error!("Unable to copy into plugin data dir: {}", e);
         }
     } else {


### PR DESCRIPTION
- Adds basic CLI flag support via `clap` crate
- Runs through basic backend startup & migration checks during CI to catch any startup errors/issues