### PR TITLE
Fix blank local file type

### DIFF
--- a/crates/client/src/components/forms/stringlist.rs
+++ b/crates/client/src/components/forms/stringlist.rs
@@ -60,8 +60,13 @@ impl Component for StringList {
             }
             Msg::HandleAdd => {
                 if let Some(el) = self.new_value_input.cast::<HtmlInputElement>() {
+                    if el.value().is_empty() {
+                        el.set_placeholder("Please enter a value");
+                        return false
+                    }
                     link.send_message(Msg::Add(el.value()));
                     el.set_value("");
+                    el.set_placeholder("html")
                 }
 
                 false


### PR DESCRIPTION
resolves #232 

Code:

Simply tests if the input value is blank

If it is, display an error message as a placeholder (making sure to reset that error message if the user adds a file extension)

If it is not, simply follow the old method of adding the extension to the list