### PR TITLE
Cache load support

### DIFF
--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -623,7 +623,10 @@ pub async fn update_or_remove_task(
     // Task already exists w/ this URL, remove this one.
     if let Some(existing) = existing_task {
         if existing.id != id {
-            crawl_tag::Entity::delete_many().filter(crawl_tag::Column::CrawlQueueId.eq(id)).exec(db).await?;
+            crawl_tag::Entity::delete_many()
+                .filter(crawl_tag::Column::CrawlQueueId.eq(id))
+                .exec(db)
+                .await?;
             Entity::delete_by_id(id).exec(db).await?;
         }
 

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -623,6 +623,7 @@ pub async fn update_or_remove_task(
     // Task already exists w/ this URL, remove this one.
     if let Some(existing) = existing_task {
         if existing.id != id {
+            crawl_tag::Entity::delete_many().filter(crawl_tag::Column::CrawlQueueId.eq(id)).exec(db).await?;
             Entity::delete_by_id(id).exec(db).await?;
         }
 

--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -1,6 +1,6 @@
 use crate::models::{document_tag, tag};
 use sea_orm::entity::prelude::*;
-use sea_orm::{ConnectionTrait, FromQueryResult, InsertResult, QuerySelect, Set, Condition};
+use sea_orm::{Condition, ConnectionTrait, FromQueryResult, InsertResult, QuerySelect, Set};
 
 use super::tag::{get_or_create, TagPair};
 
@@ -157,7 +157,10 @@ pub async fn remove_by_rule(db: &DatabaseConnection, rule: &str) -> anyhow::Resu
     if !removed.is_empty() {
         log::info!("removed {} docs due to '{}'", removed.len(), rule);
     }
-    Ok(removed.into_iter().map(|(id, doc_id)| doc_id).collect::<Vec<String>>())
+    Ok(removed
+        .into_iter()
+        .map(|(_id, doc_id)| doc_id)
+        .collect::<Vec<String>>())
 }
 
 #[cfg(test)]

--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -12,6 +12,7 @@ pub struct Model {
     /// Domain for this document, used to implement per domain crawl limits.
     pub domain: String,
     /// URL that was indexed.
+    #[sea_orm(unique)]
     pub url: String,
     /// URL used to open in a file/browser window.
     pub open_url: Option<String>,

--- a/crates/entities/src/models/lens.rs
+++ b/crates/entities/src/models/lens.rs
@@ -67,11 +67,11 @@ pub async fn reset(db: &DatabaseConnection) -> anyhow::Result<()> {
 
 // Finds the lens using the lens name
 pub async fn find_by_name(
-    lens_name: &String,
+    lens_name: &str,
     db: &DatabaseConnection,
 ) -> Result<Option<Model>, sea_orm::DbErr> {
     Entity::find()
-        .filter(Column::Name.eq(lens_name.clone()))
+        .filter(Column::Name.eq(lens_name.to_owned()))
         .one(db)
         .await
 }

--- a/crates/entities/src/models/lens.rs
+++ b/crates/entities/src/models/lens.rs
@@ -34,6 +34,8 @@ pub struct Model {
     // Trigger doesn't have to be unique, we can have multiple lenses contributing to
     // the same trigger. Can also be user updatable.
     pub trigger: Option<String>,
+    // Indicates the last time the cache was updated
+    pub last_cache_update: Option<DateTimeUtc>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]
@@ -61,6 +63,38 @@ pub async fn reset(db: &DatabaseConnection) -> anyhow::Result<()> {
         .await?;
 
     Ok(())
+}
+
+// Finds the lens using the lens name
+pub async fn find_by_name(
+    lens_name: &String,
+    db: &DatabaseConnection,
+) -> Result<Option<Model>, sea_orm::DbErr> {
+    Entity::find()
+        .filter(Column::Name.eq(lens_name.clone()))
+        .one(db)
+        .await
+}
+
+// Updates the lens row in the database with the new cache time
+pub async fn update_cache_time(
+    lens_name: &String,
+    date: DateTimeUtc,
+    db: &DatabaseConnection,
+) -> anyhow::Result<bool> {
+    let exists = Entity::find()
+        .filter(Column::Name.eq(lens_name.clone()))
+        .one(db)
+        .await?;
+
+    if let Some(existing) = exists {
+        log::debug!("Updating lens: {} with new cache date {}", lens_name, date);
+        let mut updated: ActiveModel = existing.clone().into();
+        updated.last_cache_update = Set(Option::Some(date));
+        updated.update(db).await?;
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 /// True if the lens was added, False if it already exists.

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -21,6 +21,7 @@ mod m20221121_000001_add_data_to_crawl_queue;
 mod m20221123_000001_add_document_tag_constraint;
 mod m20221124_000001_add_tags_for_existing_lenses;
 mod m20221210_000001_add_crawl_tags_table;
+mod m20230104_000001_add_column_n_index;
 mod utils;
 
 pub struct Migrator;
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221123_000001_add_document_tag_constraint::Migration),
             Box::new(m20221124_000001_add_tags_for_existing_lenses::Migration),
             Box::new(m20221210_000001_add_crawl_tags_table::Migration),
+            Box::new(m20230104_000001_add_column_n_index::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20230104_000001_add_column_n_index.rs
+++ b/crates/migrations/src/m20230104_000001_add_column_n_index.rs
@@ -1,0 +1,54 @@
+use entities::models::{indexed_document, lens};
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20230104_000001_add_column_n_index"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add lens cache column if it doesn't exist
+        if let Ok(has_col) = manager.has_column("lens", "last_cache_update").await {
+            if has_col == false {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(lens::Entity)
+                            .add_column(ColumnDef::new(Alias::new("last_cache_update")).date_time())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        // Add unique index for url column, note altering the column
+        // to make it unique is not allowed in sqlite, creating
+        // a unique index is an alternative
+        let rslt = manager
+            .create_index(
+                Index::create()
+                    .name("idx-indexed_document-url")
+                    .unique()
+                    .table(indexed_document::Entity)
+                    .col(indexed_document::Column::Url)
+                    .to_owned(),
+            )
+            .await;
+
+        // No need to fail, index may already exist
+        if let Err(err) = rslt {
+            log::error!("{:?}", err);
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/migrations/src/m20230104_000001_add_column_n_index.rs
+++ b/crates/migrations/src/m20230104_000001_add_column_n_index.rs
@@ -1,7 +1,4 @@
-use entities::{
-    models::{indexed_document, lens},
-    sea_orm::Statement,
-};
+use entities::{models::lens, sea_orm::Statement};
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::{ConnectionTrait, TransactionTrait};
 pub struct Migration;
@@ -17,7 +14,7 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         // Add lens cache column if it doesn't exist
         if let Ok(has_col) = manager.has_column("lens", "last_cache_update").await {
-            if has_col == false {
+            if !has_col {
                 manager
                     .alter_table(
                         Table::alter()
@@ -71,8 +68,8 @@ impl MigrationTrait for Migration {
                         from indexed_document where url = ? 
                         order by updated_at desc limit 1
                         )
-                    delete from document_tag where indexed_document_id in id_list and indexed_document_id not in id_keep"#
-                        .into(), vec![url.clone().into()])).await?;
+                    delete from document_tag where indexed_document_id in id_list and indexed_document_id not in id_keep"#, 
+                    vec![url.clone().into()])).await?;
 
                 // delete indexed documents
                 txn.execute(Statement::from_sql_and_values(
@@ -87,8 +84,7 @@ impl MigrationTrait for Migration {
                         from indexed_document where url = ? 
                         order by updated_at desc limit 1
                         )
-                    delete from indexed_document where id in id_list and id not in id_keep"#
-                        .into(),
+                    delete from indexed_document where id in id_list and id not in id_keep"#,
                     vec![url.into()],
                 ))
                 .await?;

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-pub use spyglass_lens::{LensConfig, LensRule, PipelineConfiguration};
+pub use spyglass_lens::{LensConfig, LensRule, LensSource, PipelineConfiguration};
 
 use crate::{
     form::{FormType, SettingOpts},
@@ -317,6 +317,10 @@ impl Config {
 
     pub fn lenses_dir(&self) -> PathBuf {
         self.data_dir().join("lenses")
+    }
+
+    pub fn cache_dir(&self) -> PathBuf {
+        self.data_dir().join("cache")
     }
 
     pub fn pipelines_dir(&self) -> PathBuf {

--- a/crates/spyglass-lens/src/lib.rs
+++ b/crates/spyglass-lens/src/lib.rs
@@ -23,6 +23,22 @@ pub enum LensRule {
     SkipURL(String),
 }
 
+/// The lens source is used to identify if the lens was provided by a remote
+/// lens provider or if it is a locally created lens. Depending on the
+/// provider different features might be available
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub enum LensSource {
+    /**
+     * Lens sourced locally
+     */
+    #[default]
+    Local,
+    /**
+     * Lens download from a remote source
+     */
+    Remote(String),
+}
+
 impl fmt::Display for LensRule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -71,6 +87,8 @@ pub struct LensConfig {
     pub trigger: String,
     #[serde(default)]
     pub pipeline: Option<String>,
+    #[serde(default)]
+    pub lens_source: LensSource,
     // Used internally & should not be serialized/deserialized
     #[serde(skip)]
     pub file_path: PathBuf,

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -32,6 +32,7 @@ open = "3.0"
 percent-encoding = "2.2"
 regex = "1"
 reqwest = "0.11"
+flate2 = "1.0.24"
 ron = "0.8"
 rusqlite = { version = "*", features = ["bundled"] }
 sentry = "0.29.0"
@@ -53,6 +54,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "std"]}
 url = "2.2"
 uuid = { version = "1.0.0", features = ["serde", "v4"], default-features = false }
 warp = "0.3"
+warc = "0.3"
 wasmer = "2.3.0"
 wasmer-wasi = "2.3.0"
 

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -40,6 +40,7 @@ sentry-tracing = "0.29.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 shared = { path = "../shared" }
+spyglass-netrunner = { git = "https://github.com/spyglass-search/netrunner.git", branch = "main" }
 spyglass-plugin = { path = "../spyglass-plugin" }
 spyglass-rpc = { path = "../spyglass-rpc" }
 tantivy = "0.18"

--- a/crates/spyglass/src/crawler/archive.rs
+++ b/crates/spyglass/src/crawler/archive.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+use warc::{WarcHeader, WarcReader};
+
+// Warc Record object
+pub struct ArchiveRecord {
+    pub status: u16,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub content: String,
+}
+
+/// Reads a WARC file from the provided path and provides a streaming record
+/// iterator
+pub fn read(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<ArchiveRecord>>> {
+    let reader = WarcReader::from_path(path)?;
+    let record_itr = reader.iter_records().map(move |record_rslt| {
+        if let Ok(record) = record_rslt {
+            let url = record
+                .header(WarcHeader::TargetURI)
+                .expect("TargetURI not set")
+                .to_string();
+
+            if let Ok(body) = String::from_utf8(record.body().into()) {
+                let (headers, content) = parse_body(&body);
+                return Option::Some(ArchiveRecord {
+                    status: 200u16,
+                    url,
+                    headers,
+                    content,
+                });
+            }
+        }
+        return Option::None;
+    });
+
+    return Ok(record_itr);
+}
+
+// Helper used to parse the body string into headers and content
+fn parse_body(body: &str) -> (Vec<(String, String)>, String) {
+    let mut headers = Vec::new();
+    let mut content = String::new();
+
+    let mut headers_finished = false;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            headers_finished = true;
+        } else {
+            match headers_finished {
+                true => content.push_str(trimmed),
+                false => {
+                    if let Some((key, value)) = trimmed.split_once(':') {
+                        headers.push((key.trim().to_string(), value.trim().to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    (headers, content)
+}

--- a/crates/spyglass/src/crawler/archive.rs
+++ b/crates/spyglass/src/crawler/archive.rs
@@ -34,7 +34,7 @@ pub fn read_warc(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<Arch
         Option::None
     });
 
-    return Ok(record_itr);
+    Ok(record_itr)
 }
 
 // Reads the parsed cache file and provides the contents as an iterator

--- a/crates/spyglass/src/crawler/archive.rs
+++ b/crates/spyglass/src/crawler/archive.rs
@@ -31,7 +31,7 @@ pub fn read_warc(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<Arch
                 });
             }
         }
-        return Option::None;
+        Option::None
     });
 
     return Ok(record_itr);

--- a/crates/spyglass/src/crawler/archive.rs
+++ b/crates/spyglass/src/crawler/archive.rs
@@ -1,3 +1,4 @@
+use libnetrunner::parser::ParseResult;
 use std::path::Path;
 use warc::{WarcHeader, WarcReader};
 
@@ -11,7 +12,7 @@ pub struct ArchiveRecord {
 
 /// Reads a WARC file from the provided path and provides a streaming record
 /// iterator
-pub fn read(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<ArchiveRecord>>> {
+pub fn read_warc(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<ArchiveRecord>>> {
     let reader = WarcReader::from_path(path)?;
     let record_itr = reader.iter_records().map(move |record_rslt| {
         if let Ok(record) = record_rslt {
@@ -34,6 +35,11 @@ pub fn read(path: &Path) -> anyhow::Result<impl Iterator<Item = Option<ArchiveRe
     });
 
     return Ok(record_itr);
+}
+
+// Reads the parsed cache file and provides the contents as an iterator
+pub fn read_parsed(path: &Path) -> anyhow::Result<impl Iterator<Item = ParseResult>> {
+    ParseResult::iter_from_gz(path)
 }
 
 // Helper used to parse the body string into headers and content

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -128,7 +128,7 @@ pub async fn bootstrap_lens_cache(state: &AppState, config: &Config, lens: &Lens
                 }
             }
             true
-        },
+        }
         Ok((Option::None, Some(_))) => {
             // No new cache, but a cache has been processed in the past
             true

--- a/crates/spyglass/src/crawler/cache.rs
+++ b/crates/spyglass/src/crawler/cache.rs
@@ -75,7 +75,7 @@ pub fn delete_cache(cache_path: &PathBuf) -> std::io::Result<()> {
 
 // Helper method used to return timestamp of the last time the lens cache was
 // downloaded
-async fn get_last_cached(state: &AppState, lens: &String) -> Option<DateTime<Utc>> {
+async fn get_last_cached(state: &AppState, lens: &str) -> Option<DateTime<Utc>> {
     let item = lens::find_by_name(lens, &state.db).await;
     match item {
         Ok(Some(model)) => model.last_cache_update,

--- a/crates/spyglass/src/crawler/cache.rs
+++ b/crates/spyglass/src/crawler/cache.rs
@@ -1,0 +1,137 @@
+use bytes::Buf;
+use chrono::{DateTime, ParseResult, TimeZone, Utc};
+use entities::models::lens;
+use entities::sea_orm::DatabaseConnection;
+use flate2::bufread::GzDecoder;
+use std::{io::Read, path::PathBuf};
+
+use http::HeaderValue;
+use reqwest::header::{HeaderMap, IF_MODIFIED_SINCE, LAST_MODIFIED};
+use reqwest::Response;
+use shared::config::Config;
+use std::io::{Error, ErrorKind, Write};
+
+use crate::state::AppState;
+
+// Root URL for the spyglass lens stroage
+const CACHE_ROOT: &str = "https://spyglass-lens-cache.s3.amazonaws.com/";
+// The header date format
+const HEADER_DATE_FMT: &str = "%a, %d %b %Y %H:%M:%S GMT";
+
+/// Requests cache from spyglass cache storage and stores it on disk. If the
+/// cache has not been updated since the last time the cache was processed
+/// then a new cache is not downloaded. In the case that no new cache file
+/// is found and an old cache file still exists one disk then the cache
+/// file reference is returned.
+pub async fn update_cache(
+    app_state: &AppState,
+    config: &Config,
+    lens: &String,
+) -> anyhow::Result<(Option<PathBuf>, Option<DateTime<Utc>>), Error> {
+    let update_time = get_last_cached(app_state, lens).await;
+    let client = reqwest::Client::new();
+
+    let lens_cache_file = format!("{}/archive.warc.gz", lens);
+
+    // Add modified since header if a last update time exists
+    let mut headers = HeaderMap::new();
+    if let Some(date) = update_time {
+        let header_val =
+            HeaderValue::from_str(format!("{}", date.format(HEADER_DATE_FMT)).as_str());
+        if let Ok(header) = header_val {
+            headers.insert(IF_MODIFIED_SINCE, header);
+        }
+    }
+
+    let req = client
+        .get(format!("{}{}", CACHE_ROOT, lens_cache_file))
+        .headers(headers);
+
+    let resp = req.send().await;
+    match resp {
+        Ok(resp) => {
+            let cache_dir = config.cache_dir();
+            let cache_file = cache_dir.join(lens).join("archive.warc");
+            if resp.status().is_success() {
+                store_cache(lens, resp, &cache_file, &app_state.db).await?;
+                return Ok((Option::Some(cache_file), update_time));
+            } else {
+                if cache_file.exists()
+                {
+                    return Ok((Option::Some(cache_file), update_time));
+                }
+                return Ok((Option::None, update_time));
+            }
+        }
+        Err(err) => {
+            log::error!("Error accessing cache - {:?}", err);
+            return Ok((Option::None, update_time));
+        },
+    }
+}
+
+/// Deletes the cache
+pub fn delete_cache(cache_path: &PathBuf) -> std::io::Result<()> {
+    std::fs::remove_file(cache_path)
+}
+
+// Helper method used to return timestamp of the last time the lens cache was 
+// downloaded
+async fn get_last_cached(state: &AppState, lens: &String) -> Option<DateTime<Utc>> {
+    let item = lens::find_by_name(lens, &state.db).await;
+    match item {
+        Ok(Some(model)) => model.last_cache_update,
+        _ => Option::None,
+    }
+}
+
+// Helper method used to store the cache to disk. The cache is streamed from the 
+// http response and sent through a gz decoder and written to disk. The max amount
+// of memory growth is the size of the gz file.
+async fn store_cache(
+    lens: &String,
+    resp: Response,
+    storage_file: &PathBuf,
+    database_connection: &DatabaseConnection,
+) -> anyhow::Result<PathBuf, Error> {
+    if let Some(parent) = storage_file.parent() {
+        let dir_rslt = std::fs::create_dir_all(parent);
+        if let Err(err) = dir_rslt {
+            return Err(Error::new(ErrorKind::Other, err));
+        }
+    }
+
+    let file_rslt = std::fs::File::create(storage_file);
+    if let Ok(mut file) = file_rslt {
+        
+        // Grab the last modified header and update the database 
+        let last_mod = resp.headers().get(LAST_MODIFIED);
+        if let Some(last_mod_date) = last_mod {
+            let date_str_result = last_mod_date.to_str();
+            if let Ok(date) = date_str_result {
+                let result: ParseResult<DateTime<Utc>> =
+                    Utc.datetime_from_str(date, HEADER_DATE_FMT);
+                if let Ok(date_obj) = result {
+                    let _ = lens::update_cache_time(lens, date_obj, database_connection).await;
+                }
+            }
+        }
+
+        if let Ok(bytes) = resp.bytes().await {
+            let mut decoder = GzDecoder::new(bytes.reader());
+            
+            // Stream data to disk 2MB at a time. This is meant to minimize
+            // additional memory growth from decompressing the file
+            let mut buffer: [u8; 2048] = [0; 2048];
+            while let Ok(n) = decoder.read(&mut buffer) {
+                if n > 0 {
+                    file.write_all(&buffer[..n]);
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    Result::Ok(storage_file.clone())
+}

--- a/crates/spyglass/src/crawler/cache.rs
+++ b/crates/spyglass/src/crawler/cache.rs
@@ -1,4 +1,4 @@
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use chrono::{DateTime, ParseResult, TimeZone, Utc};
 use entities::models::lens;
 use entities::sea_orm::DatabaseConnection;
@@ -31,7 +31,7 @@ pub async fn update_cache(
     let update_time = get_last_cached(app_state, lens).await;
     let client = reqwest::Client::new();
 
-    let lens_cache_file = format!("{}/archive.warc.gz", lens);
+    let lens_cache_file = format!("{}/parsed.gz", lens);
 
     // Add modified since header if a last update time exists
     let mut headers = HeaderMap::new();
@@ -46,18 +46,18 @@ pub async fn update_cache(
     let req = client
         .get(format!("{}{}", CACHE_ROOT, lens_cache_file))
         .headers(headers);
-
+    log::debug!("Requesting cache file {:?}", req);
     let resp = req.send().await;
+    log::debug!("Cache file response {:?}", resp);
     match resp {
         Ok(resp) => {
             let cache_dir = config.cache_dir();
-            let cache_file = cache_dir.join(lens).join("archive.warc");
+            let cache_file = cache_dir.join(lens).join("parsed.ron.gz");
             if resp.status().is_success() {
                 store_cache(lens, resp, &cache_file, &app_state.db).await?;
                 return Ok((Option::Some(cache_file), update_time));
             } else {
-                if cache_file.exists()
-                {
+                if cache_file.exists() {
                     return Ok((Option::Some(cache_file), update_time));
                 }
                 return Ok((Option::None, update_time));
@@ -66,7 +66,7 @@ pub async fn update_cache(
         Err(err) => {
             log::error!("Error accessing cache - {:?}", err);
             return Ok((Option::None, update_time));
-        },
+        }
     }
 }
 
@@ -75,7 +75,7 @@ pub fn delete_cache(cache_path: &PathBuf) -> std::io::Result<()> {
     std::fs::remove_file(cache_path)
 }
 
-// Helper method used to return timestamp of the last time the lens cache was 
+// Helper method used to return timestamp of the last time the lens cache was
 // downloaded
 async fn get_last_cached(state: &AppState, lens: &String) -> Option<DateTime<Utc>> {
     let item = lens::find_by_name(lens, &state.db).await;
@@ -85,7 +85,7 @@ async fn get_last_cached(state: &AppState, lens: &String) -> Option<DateTime<Utc
     }
 }
 
-// Helper method used to store the cache to disk. The cache is streamed from the 
+// Helper method used to store the cache to disk. The cache is streamed from the
 // http response and sent through a gz decoder and written to disk. The max amount
 // of memory growth is the size of the gz file.
 async fn store_cache(
@@ -103,8 +103,7 @@ async fn store_cache(
 
     let file_rslt = std::fs::File::create(storage_file);
     if let Ok(mut file) = file_rslt {
-        
-        // Grab the last modified header and update the database 
+        // Grab the last modified header and update the database
         let last_mod = resp.headers().get(LAST_MODIFIED);
         if let Some(last_mod_date) = last_mod {
             let date_str_result = last_mod_date.to_str();
@@ -118,18 +117,7 @@ async fn store_cache(
         }
 
         if let Ok(bytes) = resp.bytes().await {
-            let mut decoder = GzDecoder::new(bytes.reader());
-            
-            // Stream data to disk 2MB at a time. This is meant to minimize
-            // additional memory growth from decompressing the file
-            let mut buffer: [u8; 2048] = [0; 2048];
-            while let Ok(n) = decoder.read(&mut buffer) {
-                if n > 0 {
-                    file.write_all(&buffer[..n]);
-                } else {
-                    break;
-                }
-            }
+            let _ = file.write_all(&bytes);
         }
     }
 

--- a/crates/spyglass/src/crawler/mod.rs
+++ b/crates/spyglass/src/crawler/mod.rs
@@ -20,7 +20,9 @@ use crate::parser;
 use crate::scraper::{html_to_text, DEFAULT_DESC_LENGTH};
 use crate::state::AppState;
 
+pub mod archive;
 pub mod bootstrap;
+pub mod cache;
 pub mod client;
 pub mod robots;
 

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -191,6 +191,7 @@ async fn start_backend(state: &mut AppState, config: &Config) {
     // Crawlers
     let worker_handle = tokio::spawn(task::worker_task(
         state.clone(),
+        config.clone(),
         worker_cmd_rx,
         pause_tx.subscribe(),
     ));

--- a/crates/spyglass/src/pipeline/cache_pipeline.rs
+++ b/crates/spyglass/src/pipeline/cache_pipeline.rs
@@ -142,7 +142,7 @@ async fn process_records(state: &AppState, results: &mut Vec<ParseResult>) {
                 let canonical_url = &crawl_result
                     .canonical_url
                     .clone()
-                    .unwrap_or(String::from(""));
+                    .unwrap_or_else(|| String::from(""));
                 let url = Url::parse(canonical_url).expect("Invalid crawl URL");
                 let url_host = url.host_str().expect("Invalid URL host");
 

--- a/crates/spyglass/src/pipeline/cache_pipeline.rs
+++ b/crates/spyglass/src/pipeline/cache_pipeline.rs
@@ -1,0 +1,182 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::thread;
+use std::time::Instant;
+
+use crate::crawler::{CrawlResult, cache};
+use crate::pipeline::collector::{CollectionResult, DefaultCollector};
+use crate::pipeline::PipelineContext;
+use crate::search::Searcher;
+use crate::state::AppState;
+use crate::task::CrawlTask;
+
+use entities::models::{crawl_queue, indexed_document};
+use shared::config::{Config, LensConfig, PipelineConfiguration};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+use super::parser::DefaultParser;
+use crate::crawler::archive;
+use entities::sea_orm::query::*;
+use entities::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait};
+use url::Url;
+
+/// processes the cache for a lens. The cache is streamed in from the provided path
+/// and processed. After the process is complete the cache is deleted
+pub async fn process_update(state: AppState, cache_path: PathBuf) {
+    let records = archive::read(&cache_path);
+    match records {
+        Ok(mut record_iter) => {
+            let mut record_list: Vec<JoinHandle<Option<CrawlResult>>> = Vec::new();
+            while let Some(record) = record_iter.next() {
+                if let Some(archive_record) = record {
+                    let result = CollectionResult {
+                        content: CrawlResult {
+                            content: Some(archive_record.content),
+                            url: archive_record.url.clone(),
+                            open_url: Some(archive_record.url),
+                            ..Default::default()
+                        },
+                    };
+                    let new_state = state.clone();
+                    let parser = DefaultParser::new();
+                    record_list.push(tokio::spawn(async move {
+                        let mut context = PipelineContext::new("Cache Pipeline", new_state.clone());
+
+                        let parse_result = parser.parse(&mut context, &result.content).await;
+
+                        match parse_result {
+                            Ok(parse_result) => {
+                                let crawl_result = parse_result.content;
+                                return Some(crawl_result);
+                            }
+                            _ => Option::None,
+                        }
+                    }));
+
+                    if record_list.len() >= 500 {
+                        let mut results: Vec<CrawlResult> = Vec::new();
+                        for task in record_list {
+                            if let Ok(Some(result)) = task.await {
+                                results.push(result);
+                            }
+                        }
+                        process_records(&state, &mut results).await;
+                        record_list = Vec::new();
+                    }
+                }
+            }
+
+            if record_list.len() > 0 {
+                let mut results: Vec<CrawlResult> = Vec::new();
+                for task in record_list {
+                    if let Ok(Some(result)) = task.await {
+                        results.push(result);
+                    }
+                }
+                process_records(&state, &mut results).await;
+            }
+        }
+        Err(error) => {
+            log::error!("Got an error reading archive {:?}", error);
+        }
+    }
+    
+    // attempt to remove processed cache file
+    let _ = cache::delete_cache(&cache_path);
+}
+
+// Process a list of crawl results. The following steps will be taken:
+// 1. Find all urls that already have been processed in the database
+// 2. Remove any documents that already exist from the index
+// 3. Add all new results to the index
+// 4. Insert all new documents to the indexed document database
+async fn process_records(state: &AppState, results: &mut Vec<CrawlResult>) {
+    let find = indexed_document::Entity::find();
+    let mut condition = Condition::any();
+
+    for result in &mut *results {
+        condition = condition.add(indexed_document::Column::Url.eq(result.url.as_str()));
+    }
+    let existing: Vec<indexed_document::Model> = find
+        .filter(condition)
+        .all(&state.db)
+        .await
+        .unwrap_or_default();
+    let mut id_map = HashMap::new();
+
+    for model in &existing {
+        let _ = id_map.insert(model.url.to_string(), model.doc_id.clone());
+        let _ = Searcher::delete_by_id(&state, model.doc_id.as_str()).await;
+    }
+
+    let _ = Searcher::save(&state);
+
+    let transaction_rslt = state.db.begin().await;
+    match transaction_rslt {
+        Ok(transaction) => {
+            let mut updates = Vec::new();
+            for crawl_result in results {
+                if let Some(content) = &crawl_result.content {
+                    log::debug!("Cache Pipeline got content");
+                    let url = Url::parse(&crawl_result.url).expect("Invalid crawl URL");
+                    let url_host = url.host_str().expect("Invalid URL host");
+
+                    // Add document to index
+                    let doc_id: Option<String> = {
+                        if let Ok(mut index_writer) = state.index.writer.lock() {
+                            match Searcher::upsert_document(
+                                &mut index_writer,
+                                id_map.get(&crawl_result.url).cloned(),
+                                &crawl_result.title.clone().unwrap_or_default(),
+                                &crawl_result.description.clone().unwrap_or_default(),
+                                url_host,
+                                url.as_str(),
+                                &content,
+                            ) {
+                                Ok(new_doc_id) => Some(new_doc_id),
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        }
+                    };
+
+                    if let Some(new_id) = doc_id {
+                        if id_map.contains_key(&new_id) == false {
+                            let update = indexed_document::ActiveModel {
+                                domain: Set(url_host.to_string()),
+                                url: Set(url.as_str().to_string()),
+                                doc_id: Set(new_id),
+                                ..Default::default()
+                            };
+
+                            updates.push(update);
+                        }
+                    }
+                }
+            }
+
+            let doc_insert = indexed_document::Entity::insert_many(updates)
+                .on_conflict(
+                    entities::sea_orm::sea_query::OnConflict::columns(vec![
+                        indexed_document::Column::OpenUrl,
+                    ])
+                    .do_nothing()
+                    .to_owned(),
+                )
+                .exec(&transaction)
+                .await;
+
+            if let Err(error) = doc_insert {
+                log::error!("Insert many failed {:?}", error);
+            }
+
+            let commit = transaction.commit().await;
+            if let Err(error) = commit {
+                log::error!("Failed to commit transaction {:?}", error);
+            }
+        }
+        Err(err) => log::error!("Transaction failed {:?}", err),
+    }
+}

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -127,7 +127,7 @@ async fn start_crawl(
                         // Delete old document, if any.
                         if let Some(doc) = &existing {
                             let _ = Searcher::delete_by_id(&state, &doc.doc_id).await;
-                            let _ = Searcher::save(&state);
+                            let _ = Searcher::save(&state).await;
                         }
 
                         // Add document to index

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -53,6 +53,9 @@ pub async fn pipeline_loop(
                     );
                     start_crawl(state.clone(), &pipeline, &collector, &parser, crawl_task).await;
                 }
+                PipelineCommand::ProcessCache(_) => { 
+                    // noop 
+                }
             }
         }
 
@@ -77,7 +80,7 @@ async fn start_crawl(
 
     match collection_result {
         Ok(result) => {
-            let parse_result = parser.parse(&mut context, task.id, &result.content).await;
+            let parse_result = parser.parse(&mut context, &result.content).await;
 
             match parse_result {
                 Ok(parse_result) => {

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -53,8 +53,8 @@ pub async fn pipeline_loop(
                     );
                     start_crawl(state.clone(), &pipeline, &collector, &parser, crawl_task).await;
                 }
-                PipelineCommand::ProcessCache(_) => { 
-                    // noop 
+                PipelineCommand::ProcessCache(_) => {
+                    // noop
                 }
             }
         }

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -1,3 +1,4 @@
+pub mod cache_pipeline;
 pub mod collector;
 pub mod default_pipeline;
 pub mod parser;
@@ -11,6 +12,7 @@ use shared::config::PipelineConfiguration;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
+use std::path::PathBuf;
 use tokio::sync::mpsc;
 
 // The pipeline context is a context object that is passed between
@@ -39,6 +41,7 @@ impl PipelineContext {
 #[derive(Debug, Clone)]
 pub enum PipelineCommand {
     ProcessUrl(String, CrawlTask),
+    ProcessCache(PathBuf),
 }
 
 // General pipeline initialize function. This function will read the lenses and pipelines
@@ -125,6 +128,9 @@ pub async fn initialize_pipelines(
                             fail_crawl_cmd(&app_state, task.id).await;
                         }
                     }
+                }
+                PipelineCommand::ProcessCache(cache_file) => {
+                    cache_pipeline::process_update(app_state.clone(), cache_file).await;
                 }
             }
         }

--- a/crates/spyglass/src/pipeline/parser.rs
+++ b/crates/spyglass/src/pipeline/parser.rs
@@ -16,7 +16,6 @@ impl DefaultParser {
     pub async fn parse(
         &self,
         _context: &mut PipelineContext,
-        _task_id: i64,
         crawl_result: &CrawlResult,
     ) -> Result<ParseResult, String> {
         if let Some(raw_content) = &crawl_result.content {

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -1,6 +1,6 @@
-use std::fs;
 use entities::models::lens;
 use entities::sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use std::fs;
 
 use shared::config::{Config, LensConfig};
 use spyglass_plugin::SearchFilter;

--- a/crates/spyglass/src/search/lens.rs
+++ b/crates/spyglass/src/search/lens.rs
@@ -1,15 +1,10 @@
 use std::fs;
+use entities::models::lens;
+use entities::sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 
-use entities::models::crawl_queue::EnqueueSettings;
-use entities::models::{crawl_queue, indexed_document, lens};
-use entities::sea_orm::{ColumnTrait, EntityTrait, ModelTrait, QueryFilter};
-use shared::regex::{regex_for_robots, WildcardType};
-use url::Url;
-
-use shared::config::{Config, LensConfig, LensRule};
+use shared::config::{Config, LensConfig};
 use spyglass_plugin::SearchFilter;
 
-use crate::search::Searcher;
 use crate::state::AppState;
 use crate::task::{CollectTask, ManagerCommand};
 
@@ -57,137 +52,15 @@ pub async fn load_lenses(state: AppState) {
     // Check & bootstrap will go through domains/prefixes and bootstrap a crawl queue
     // if we have not already done so.
     for lens in new_lenses {
-        for domain in lens.domains.iter() {
-            let pipeline_kind = lens.pipeline.as_ref().cloned();
-
-            let seed_url = format!("https://{}", domain);
-            let _ = state
-                .schedule_work(ManagerCommand::Collect(CollectTask::Bootstrap {
-                    lens: lens.name.clone(),
-                    seed_url,
-                    pipeline: pipeline_kind.clone(),
-                }))
-                .await;
-        }
-
-        process_urls(&lens, &state).await;
-        process_lens_rules(lens, &state).await;
+        log::debug!("Scheduling lens bootstrap {:?}", lens);
+        let _ = state
+            .schedule_work(ManagerCommand::Collect(CollectTask::BootstrapLens {
+                lens: lens.name.clone(),
+            }))
+            .await;
     }
 
     log::info!("✅ finished lens checks")
-}
-
-pub async fn process_urls(lens: &LensConfig, state: &AppState) {
-    let pipeline_kind = lens.pipeline.as_ref().cloned();
-
-    for prefix in lens.urls.iter() {
-        // Handle singular URL matches. Simply add these to the crawl queue.
-        if prefix.ends_with('$') {
-            // Remove the '$' suffix and add to the crawl queue
-            let url = prefix.strip_suffix('$').expect("No $ at end of prefix");
-            if let Err(err) = crawl_queue::enqueue_all(
-                &state.db,
-                &[url.to_owned()],
-                &[],
-                &state.user_settings,
-                &EnqueueSettings {
-                    force_allow: true,
-                    ..Default::default()
-                },
-                pipeline_kind.clone(),
-            )
-            .await
-            {
-                log::warn!("unable to enqueue <{}> due to {}", prefix, err)
-            }
-        } else {
-            // Otherwise, bootstrap using this as a prefix.
-            let _ = state
-                .schedule_work(ManagerCommand::Collect(CollectTask::Bootstrap {
-                    lens: lens.name.clone(),
-                    seed_url: prefix.to_string(),
-                    pipeline: pipeline_kind.clone(),
-                }))
-                .await;
-        }
-    }
-}
-
-async fn process_lens_rules(lens: LensConfig, state: &AppState) {
-    // Rules will go through and remove crawl tasks AND indexed_documents that match.
-    for rule in lens.rules.iter() {
-        match rule {
-            LensRule::SkipURL(rule_str) => {
-                if let Some(rule_like) = regex_for_robots(rule_str, WildcardType::Database) {
-                    // Remove matching crawl tasks
-                    let _ = crawl_queue::remove_by_rule(&state.db, &rule_like).await;
-                    // Remove matching indexed documents
-                    match indexed_document::remove_by_rule(&state.db, &rule_like).await {
-                        Ok(doc_ids) => {
-                            for doc_id in doc_ids {
-                                let _ = Searcher::delete_by_id(state, &doc_id).await;
-                            }
-                            let _ = Searcher::save(state);
-                        }
-                        Err(e) => log::error!("Unable to remove docs: {:?}", e),
-                    }
-                }
-            }
-            LensRule::LimitURLDepth(rule_str, _) => {
-                // Remove URLs that don't match this rule
-                // sqlite3 does support regexp, but this is _not_ guaranteed to
-                // be on all platforms, so we'll apply this in a brute-force way.
-                if let Ok(parsed) = Url::parse(rule_str) {
-                    if let Some(domain) = parsed.host_str() {
-                        // Remove none matchin URLs from crawl_queue
-                        let urls = crawl_queue::Entity::find()
-                            .filter(crawl_queue::Column::Domain.eq(domain))
-                            .all(&state.db)
-                            .await;
-
-                        let regex = regex::Regex::new(&rule.to_regex())
-                            .expect("Invalid LimitURLDepth regex");
-
-                        let mut num_removed = 0;
-                        if let Ok(urls) = urls {
-                            for crawl in urls {
-                                if !regex.is_match(&crawl.url) {
-                                    num_removed += 1;
-                                    let _ = crawl.delete(&state.db).await;
-                                }
-                            }
-                        }
-                        log::info!("removed {} docs from crawl_queue", num_removed);
-
-                        // Remove none matchin URLs from indexed documents
-                        let mut num_removed = 0;
-                        let indexed = indexed_document::Entity::find()
-                            .filter(indexed_document::Column::Domain.eq(domain))
-                            .all(&state.db)
-                            .await;
-
-                        let mut doc_ids = Vec::new();
-                        if let Ok(indexed) = indexed {
-                            for doc in indexed {
-                                if !regex.is_match(&doc.url) {
-                                    num_removed += 1;
-                                    doc_ids.push(doc.doc_id.clone());
-                                    let _ = doc.delete(&state.db).await;
-                                }
-                            }
-                        }
-
-                        for doc_id in doc_ids {
-                            let _ = Searcher::delete_by_id(state, &doc_id).await;
-                        }
-                        let _ = Searcher::save(state);
-
-                        log::info!("removed {} docs from indexed_documents", num_removed);
-                    }
-                }
-            }
-        }
-    }
 }
 
 /// Utility function to map a trigger to the matching lens(es) & convert that into

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -3,7 +3,7 @@ use notify::{EventKind, RecursiveMode, Watcher};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 
-use shared::config::{Config, LensConfig};
+use shared::config::Config;
 
 use crate::connection::load_connection;
 use crate::crawler::bootstrap;

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -3,7 +3,7 @@ use notify::{EventKind, RecursiveMode, Watcher};
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc};
 
-use shared::config::Config;
+use shared::config::{Config, LensConfig};
 
 use crate::connection::load_connection;
 use crate::crawler::bootstrap;
@@ -21,6 +21,9 @@ pub struct CrawlTask {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CollectTask {
+    BootstrapLens {
+        lens: String,
+    },
     // Pull URLs from a CDX server
     Bootstrap {
         lens: String,
@@ -135,6 +138,7 @@ pub async fn manager_task(
 /// Grabs a task
 pub async fn worker_task(
     state: AppState,
+    config: Config,
     mut queue: mpsc::Receiver<WorkerCommand>,
     mut pause_rx: broadcast::Receiver<AppPause>,
 ) {
@@ -169,6 +173,19 @@ pub async fn worker_task(
                 if let Some(cmd) = res {
                     match cmd {
                         WorkerCommand::Collect(task) => match task {
+                            CollectTask::BootstrapLens {
+                                lens
+                            } => {
+                                log::debug!("Handling Bootstrap for {}", lens);
+                                let state = state.clone();
+                                let config = config.clone();
+                                tokio::spawn(async move {
+                                    if let Some(lens_config) = &state.lenses.get(&lens) {
+                                        worker::handle_bootstrap_lens(&state, &config, lens_config)
+                                            .await;
+                                    }
+                                });
+                            },
                             CollectTask::Bootstrap {
                                 lens,
                                 seed_url,

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -13,7 +13,7 @@ use crate::crawler::{CrawlError, CrawlResult, Crawler};
 use crate::search::Searcher;
 use crate::state::AppState;
 
-/// Handles bootstrapping a lens. If the lens is remote we attempt to process the cache. 
+/// Handles bootstrapping a lens. If the lens is remote we attempt to process the cache.
 /// If no cache is accessible then we run the standard bootstrap process. Local lenses use
 /// the standard bootstrap process
 #[tracing::instrument(skip(state, config, lens))]
@@ -87,7 +87,7 @@ async fn process_urls(lens: &LensConfig, state: &AppState) {
     }
 }
 
-// Processes the len rules 
+// Processes the len rules
 async fn process_lens_rules(lens: &LensConfig, state: &AppState) {
     // Rules will go through and remove crawl tasks AND indexed_documents that match.
     for rule in lens.rules.iter() {

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -17,7 +17,7 @@ use crate::state::AppState;
 /// If no cache is accessible then we run the standard bootstrap process. Local lenses use
 /// the standard bootstrap process
 #[tracing::instrument(skip(state, config, lens))]
-pub async fn handle_bootstrap_lens(state: &AppState, config: &Config, lens: &LensConfig) -> () {
+pub async fn handle_bootstrap_lens(state: &AppState, config: &Config, lens: &LensConfig) {
     log::debug!("Bootstrapping Lens");
     match &lens.lens_source {
         LensSource::Remote(_) => {
@@ -32,7 +32,7 @@ pub async fn handle_bootstrap_lens(state: &AppState, config: &Config, lens: &Len
 }
 
 // Process lens by kicking off a bootstrap for the lens
-async fn process_lens(state: &AppState, lens: &LensConfig) -> () {
+async fn process_lens(state: &AppState, lens: &LensConfig) {
     for domain in lens.domains.iter() {
         let pipeline_kind = lens.pipeline.as_ref().cloned();
 

--- a/crates/spyglass/src/task/worker.rs
+++ b/crates/spyglass/src/task/worker.rs
@@ -1,15 +1,169 @@
+use entities::models::crawl_queue::EnqueueSettings;
+use shared::regex::{regex_for_robots, WildcardType};
 use url::Url;
 
 use entities::models::{bootstrap_queue, crawl_queue, indexed_document, tag};
 use entities::sea_orm::prelude::*;
 use entities::sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
-use shared::config::LensConfig;
+use shared::config::{Config, LensConfig, LensRule, LensSource};
 
-use super::bootstrap;
 use super::CrawlTask;
+use super::{bootstrap, CollectTask, ManagerCommand};
 use crate::crawler::{CrawlError, CrawlResult, Crawler};
 use crate::search::Searcher;
 use crate::state::AppState;
+
+/// Handles bootstrapping a lens. If the lens is remote we attempt to process the cache. 
+/// If no cache is accessible then we run the standard bootstrap process. Local lenses use
+/// the standard bootstrap process
+#[tracing::instrument(skip(state, config, lens))]
+pub async fn handle_bootstrap_lens(state: &AppState, config: &Config, lens: &LensConfig) -> () {
+    log::debug!("Bootstrapping Lens");
+    match &lens.lens_source {
+        LensSource::Remote(_) => {
+            if bootstrap::bootstrap_lens_cache(state, config, lens).await == false {
+                process_lens(state, lens).await;
+            }
+        }
+        _ => {
+            process_lens(state, lens).await;
+        }
+    }
+}
+
+// Process lens by kicking off a bootstrap for the lens
+async fn process_lens(state: &AppState, lens: &LensConfig) -> () {
+    for domain in lens.domains.iter() {
+        let pipeline_kind = lens.pipeline.as_ref().cloned();
+
+        let seed_url = format!("https://{}", domain);
+        let _ = state
+            .schedule_work(ManagerCommand::Collect(CollectTask::Bootstrap {
+                lens: lens.name.clone(),
+                seed_url,
+                pipeline: pipeline_kind.clone(),
+            }))
+            .await;
+    }
+
+    process_urls(&lens, &state).await;
+    process_lens_rules(&lens, &state).await;
+}
+
+// Process the urls by adding them to the crawl queue or bootstrapping the urls
+async fn process_urls(lens: &LensConfig, state: &AppState) {
+    let pipeline_kind = lens.pipeline.as_ref().cloned();
+
+    for prefix in lens.urls.iter() {
+        // Handle singular URL matches. Simply add these to the crawl queue.
+        if prefix.ends_with('$') {
+            // Remove the '$' suffix and add to the crawl queue
+            let url = prefix.strip_suffix('$').expect("No $ at end of prefix");
+            if let Err(err) = crawl_queue::enqueue_all(
+                &state.db,
+                &[url.to_owned()],
+                &[],
+                &state.user_settings,
+                &EnqueueSettings {
+                    force_allow: true,
+                    ..Default::default()
+                },
+                pipeline_kind.clone(),
+            )
+            .await
+            {
+                log::warn!("unable to enqueue <{}> due to {}", prefix, err)
+            }
+        } else {
+            // Otherwise, bootstrap using this as a prefix.
+            let _ = state
+                .schedule_work(ManagerCommand::Collect(CollectTask::Bootstrap {
+                    lens: lens.name.clone(),
+                    seed_url: prefix.to_string(),
+                    pipeline: pipeline_kind.clone(),
+                }))
+                .await;
+        }
+    }
+}
+
+// Processes the len rules 
+async fn process_lens_rules(lens: &LensConfig, state: &AppState) {
+    // Rules will go through and remove crawl tasks AND indexed_documents that match.
+    for rule in lens.rules.iter() {
+        match rule {
+            LensRule::SkipURL(rule_str) => {
+                if let Some(rule_like) = regex_for_robots(rule_str, WildcardType::Database) {
+                    // Remove matching crawl tasks
+                    let _ = crawl_queue::remove_by_rule(&state.db, &rule_like).await;
+                    // Remove matching indexed documents
+                    match indexed_document::remove_by_rule(&state.db, &rule_like).await {
+                        Ok(doc_ids) => {
+                            for doc_id in doc_ids {
+                                let _ = Searcher::delete_by_id(state, &doc_id).await;
+                            }
+                            let _ = Searcher::save(state);
+                        }
+                        Err(e) => log::error!("Unable to remove docs: {:?}", e),
+                    }
+                }
+            }
+            LensRule::LimitURLDepth(rule_str, _) => {
+                // Remove URLs that don't match this rule
+                // sqlite3 does support regexp, but this is _not_ guaranteed to
+                // be on all platforms, so we'll apply this in a brute-force way.
+                if let Ok(parsed) = Url::parse(rule_str) {
+                    if let Some(domain) = parsed.host_str() {
+                        // Remove none matchin URLs from crawl_queue
+                        let urls = crawl_queue::Entity::find()
+                            .filter(crawl_queue::Column::Domain.eq(domain))
+                            .all(&state.db)
+                            .await;
+
+                        let regex = regex::Regex::new(&rule.to_regex())
+                            .expect("Invalid LimitURLDepth regex");
+
+                        let mut num_removed = 0;
+                        if let Ok(urls) = urls {
+                            for crawl in urls {
+                                if !regex.is_match(&crawl.url) {
+                                    num_removed += 1;
+                                    let _ = crawl.delete(&state.db).await;
+                                }
+                            }
+                        }
+                        log::info!("removed {} docs from crawl_queue", num_removed);
+
+                        // Remove none matchin URLs from indexed documents
+                        let mut num_removed = 0;
+                        let indexed = indexed_document::Entity::find()
+                            .filter(indexed_document::Column::Domain.eq(domain))
+                            .all(&state.db)
+                            .await;
+
+                        let mut doc_ids = Vec::new();
+                        if let Ok(indexed) = indexed {
+                            for doc in indexed {
+                                if !regex.is_match(&doc.url) {
+                                    num_removed += 1;
+                                    doc_ids.push(doc.doc_id.clone());
+                                    let _ = doc.delete(&state.db).await;
+                                }
+                            }
+                        }
+
+                        for doc_id in doc_ids {
+                            let _ = Searcher::delete_by_id(state, &doc_id).await;
+                        }
+                        let _ = Searcher::save(state);
+
+                        log::info!("removed {} docs from indexed_documents", num_removed);
+                    }
+                }
+            }
+        }
+    }
+}
 
 /// Check if we've already bootstrapped a prefix / otherwise add it to the queue.
 #[tracing::instrument(skip(state, lens))]


### PR DESCRIPTION
Update to lens bootstrapping to branch processing between "remote" and "local" lens files. Remote lens will now check for index caches to bootstrap local index instead of crawling. Local lens will continue to crawl as normal. 