### PR TITLE
Addition of cache tagging

### DIFF
--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -131,7 +131,7 @@ pub async fn indexed_stats(
 /// Inserts an entry into the tag table for each document and
 /// tag pair provided
 pub async fn insert_tags_many<C: ConnectionTrait>(
-    docs: &Vec<Model>,
+    docs: &[Model],
     db: &C,
     tags: &[TagPair],
 ) -> Result<InsertResult<document_tag::ActiveModel>, DbErr> {
@@ -146,7 +146,7 @@ pub async fn insert_tags_many<C: ConnectionTrait>(
     // create connections for each tag
     let doc_tags = docs
         .iter()
-        .map(|model| {
+        .flat_map(|model| {
             tag_models.iter().map(|t| document_tag::ActiveModel {
                 indexed_document_id: Set(model.id),
                 tag_id: Set(t.id),
@@ -155,7 +155,6 @@ pub async fn insert_tags_many<C: ConnectionTrait>(
                 ..Default::default()
             })
         })
-        .flatten()
         .collect::<Vec<document_tag::ActiveModel>>();
 
     // Insert connections, ignoring duplicates

--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -128,6 +128,50 @@ pub async fn indexed_stats(
     Ok(res)
 }
 
+/// Inserts an entry into the tag table for each document and
+/// tag pair provided
+pub async fn insert_tags_many<C: ConnectionTrait>(
+    docs: &Vec<Model>,
+    db: &C,
+    tags: &[TagPair],
+) -> Result<InsertResult<document_tag::ActiveModel>, DbErr> {
+    let mut tag_models: Vec<tag::Model> = Vec::new();
+    for (label, value) in tags.iter() {
+        match get_or_create(db, label.to_owned(), value).await {
+            Ok(tag) => tag_models.push(tag),
+            Err(err) => log::error!("{}", err),
+        }
+    }
+
+    // create connections for each tag
+    let doc_tags = docs
+        .iter()
+        .map(|model| {
+            tag_models.iter().map(|t| document_tag::ActiveModel {
+                indexed_document_id: Set(model.id),
+                tag_id: Set(t.id),
+                created_at: Set(chrono::Utc::now()),
+                updated_at: Set(chrono::Utc::now()),
+                ..Default::default()
+            })
+        })
+        .flatten()
+        .collect::<Vec<document_tag::ActiveModel>>();
+
+    // Insert connections, ignoring duplicates
+    document_tag::Entity::insert_many(doc_tags)
+        .on_conflict(
+            sea_orm::sea_query::OnConflict::columns(vec![
+                document_tag::Column::IndexedDocumentId,
+                document_tag::Column::TagId,
+            ])
+            .do_nothing()
+            .to_owned(),
+        )
+        .exec(db)
+        .await
+}
+
 /// Remove documents from the indexed_document table that match `rule`. Rule is expected
 /// to be a SQL like statement.
 pub async fn remove_by_rule(db: &DatabaseConnection, rule: &str) -> anyhow::Result<Vec<String>> {

--- a/crates/spyglass/src/crawler/bootstrap.rs
+++ b/crates/spyglass/src/crawler/bootstrap.rs
@@ -122,7 +122,7 @@ pub async fn bootstrap_lens_cache(state: &AppState, config: &Config, lens: &Lens
         Ok((Some(cache_file), _)) => {
             if let Some(pipeline_tx) = state.pipeline_cmd_tx.lock().await.as_mut() {
                 log::debug!("Sending cache task to pipeline");
-                let cmd = PipelineCommand::ProcessCache(cache_file);
+                let cmd = PipelineCommand::ProcessCache(lens.name.clone(), cache_file);
                 if let Err(err) = pipeline_tx.send(cmd).await {
                     log::error!("Unable to send cache task to pipeline {:?}", err);
                 }

--- a/crates/spyglass/src/pipeline/cache_pipeline.rs
+++ b/crates/spyglass/src/pipeline/cache_pipeline.rs
@@ -112,7 +112,7 @@ pub async fn process_update(state: AppState, lens: String, cache_path: PathBuf) 
 // 2. Remove any documents that already exist from the index
 // 3. Add all new results to the index
 // 4. Insert all new documents to the indexed document database
-async fn process_records(state: &AppState, lens: &String, results: &mut Vec<ParseResult>) {
+async fn process_records(state: &AppState, lens: &str, results: &mut Vec<ParseResult>) {
     let find = indexed_document::Entity::find();
     let mut condition = Condition::any();
 
@@ -213,7 +213,7 @@ async fn process_records(state: &AppState, lens: &String, results: &mut Vec<Pars
                         let result = indexed_document::insert_tags_many(
                             &added_entries,
                             &state.db,
-                            &vec![(TagType::Lens, lens.clone())],
+                            &[(TagType::Lens, lens.to_string())],
                         )
                         .await;
                         if let Err(error) = result {

--- a/crates/spyglass/src/pipeline/default_pipeline.rs
+++ b/crates/spyglass/src/pipeline/default_pipeline.rs
@@ -53,7 +53,7 @@ pub async fn pipeline_loop(
                     );
                     start_crawl(state.clone(), &pipeline, &collector, &parser, crawl_task).await;
                 }
-                PipelineCommand::ProcessCache(_) => {
+                PipelineCommand::ProcessCache(_, _) => {
                     // noop
                 }
             }

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -41,7 +41,7 @@ impl PipelineContext {
 #[derive(Debug, Clone)]
 pub enum PipelineCommand {
     ProcessUrl(String, CrawlTask),
-    ProcessCache(PathBuf),
+    ProcessCache(String, PathBuf),
 }
 
 // General pipeline initialize function. This function will read the lenses and pipelines
@@ -129,8 +129,8 @@ pub async fn initialize_pipelines(
                         }
                     }
                 }
-                PipelineCommand::ProcessCache(cache_file) => {
-                    cache_pipeline::process_update(app_state.clone(), cache_file).await;
+                PipelineCommand::ProcessCache(lens, cache_file) => {
+                    cache_pipeline::process_update(app_state.clone(), lens, cache_file).await;
                 }
             }
         }


### PR DESCRIPTION
Lens cache processing has been updated to tag the documents after being added. Currently the documents are only tagged with their associated lens. 