### PR TITLE
tweak: Change lens updater to send requests to server

### DIFF
--- a/crates/client/public/fixtures.js
+++ b/crates/client/public/fixtures.js
@@ -248,8 +248,8 @@ export async function delete_domain(domain) {
     return await invoke('delete_domain', { domain });
 }
 
-export async function install_lens(downloadUrl) {
-    return await invoke('install_lens', { downloadUrl })
+export async function install_lens(name) {
+    return await invoke('install_lens', { name })
 }
 
 export async function network_change(isOffline) {

--- a/crates/client/public/glue.js
+++ b/crates/client/public/glue.js
@@ -13,8 +13,8 @@ export async function delete_domain(domain) {
     return await invoke('delete_domain', { domain });
 }
 
-export async function install_lens(downloadUrl) {
-    return await invoke('install_lens', { downloadUrl })
+export async function install_lens(name) {
+    return await invoke('install_lens', { name })
 }
 
 export async function network_change(isOffline) {

--- a/crates/client/src/components/forms/mod.rs
+++ b/crates/client/src/components/forms/mod.rs
@@ -141,7 +141,7 @@ impl Component for FormElement {
         let label = if parent != "_" {
             html! {
                 <>
-                    <span class="text-white">{format!("{}: ", parent)}</span>
+                    <span class="text-white">{format!("{parent}: ")}</span>
                     <span>{props.opts.label.clone()}</span>
                 </>
             }

--- a/crates/client/src/components/icons.rs
+++ b/crates/client/src/components/icons.rs
@@ -319,14 +319,14 @@ pub fn file_ext_icon(props: &FileExtIconProps) -> Html {
 #[function_component(GoogleSignIn)]
 pub fn google_signin_btn(props: &IconProps) -> Html {
     html! {
-        <img src="/google_signin.png" class={props.class()} />
+        <img src="/google_signin.png" alt="Google Signin" class={props.class()} />
     }
 }
 
 #[function_component(GoogleSignInDisabled)]
 pub fn google_signin_disabled(props: &IconProps) -> Html {
     html! {
-        <img src="/google_signin_disabled.png" class={props.class()} />
+        <img src="/google_signin_disabled.png" alt="Google Signin Disabled" class={props.class()} />
     }
 }
 

--- a/crates/client/src/components/result.rs
+++ b/crates/client/src/components/result.rs
@@ -37,13 +37,13 @@ fn render_icon(result: &SearchResult) -> Html {
                     html! { <icons::FileExtIcon ext={ext.to_string()} class={icon_size} /> }
                 } else {
                     html! {
-                        <img class={icon_size} src={format!("https://favicon.spyglass.workers.dev/{}", domain.clone())} />
+                        <img class={icon_size} alt="File" src={format!("https://favicon.spyglass.workers.dev/{}", domain.clone())} />
                     }
                 }
             }
             _ => {
                 html! {
-                    <img class={icon_size} src={format!("https://favicon.spyglass.workers.dev/{}", domain.clone())} />
+                    <img class={icon_size} alt="Website" src={format!("https://favicon.spyglass.workers.dev/{}", domain.clone())} />
                 }
             }
         }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -32,7 +32,7 @@ extern "C" {
     pub async fn delete_domain(domain: String) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch)]
-    pub async fn install_lens(download_url: String) -> Result<(), JsValue>;
+    pub async fn install_lens(name: String) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch)]
     pub async fn save_user_settings(settings: JsValue) -> Result<JsValue, JsValue>;
@@ -86,7 +86,7 @@ extern "C" {
     pub async fn delete_domain(domain: String) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch)]
-    pub async fn install_lens(download_url: String) -> Result<(), JsValue>;
+    pub async fn install_lens(name: String) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch)]
     pub async fn save_user_settings(settings: JsValue) -> Result<JsValue, JsValue>;

--- a/crates/client/src/pages/connection_manager.rs
+++ b/crates/client/src/pages/connection_manager.rs
@@ -50,7 +50,7 @@ impl ConnectionsManagerPage {
     pub async fn fetch_connections() -> Result<ListConnectionResult, String> {
         match tauri_invoke(ClientInvoke::ListConnections, "".to_string()).await {
             Ok(results) => Ok(results),
-            Err(e) => Err(format!("Error fetching connections: {:?}", e)),
+            Err(e) => Err(format!("Error fetching connections: {e:?}")),
         }
     }
 

--- a/crates/client/src/pages/crawl_stats.rs
+++ b/crates/client/src/pages/crawl_stats.rs
@@ -87,7 +87,7 @@ fn stats_bar(props: &StatsBarProps) -> Html {
     );
 
     html! {
-        <div class={bar_style} style={format!("width: {}%", percent)}>
+        <div class={bar_style} style={format!("width: {percent}%")}>
             <span class="text-xs">{buf.as_str()}</span>
         </div>
     }

--- a/crates/client/src/pages/lens_manager.rs
+++ b/crates/client/src/pages/lens_manager.rs
@@ -69,23 +69,23 @@ async fn fetch_available_lenses() -> Option<Vec<LensResult>> {
 
 #[derive(Properties, PartialEq, Eq)]
 pub struct InstallBtnProps {
-    pub download_url: String,
+    pub name: String,
 }
 
 #[function_component(InstallButton)]
 pub fn install_btn(props: &InstallBtnProps) -> Html {
     let is_installing = use_state_eq(|| false);
-    let download_url = props.download_url.clone();
+    let name = props.name.clone();
 
     let onclick = {
         let is_installing = is_installing.clone();
         Callback::from(move |_| {
-            let download_url = download_url.clone();
+            let name = name.clone();
             is_installing.set(true);
             // Download to lens directory
             spawn_local(async move {
-                if let Err(e) = install_lens(download_url.clone()).await {
-                    log::error!("error installing lens: {} {:?}", download_url.clone(), e);
+                if let Err(e) = install_lens(name.clone()).await {
+                    log::error!("error installing lens: {} {:?}", name.clone(), e);
                 }
             });
         })
@@ -123,7 +123,7 @@ pub fn lens_component(props: &LensProps) -> Html {
             </div>
         }
     } else {
-        html! { <InstallButton download_url={result.download_url.clone().expect("Invalid lens download URL")} /> }
+        html! { <InstallButton name={result.title.clone()} /> }
     };
 
     let view_link = if result.html_url.is_some() {

--- a/crates/client/src/pages/plugin_manager.rs
+++ b/crates/client/src/pages/plugin_manager.rs
@@ -109,9 +109,9 @@ impl Component for PluginManagerPage {
                     match invoke(ClientInvoke::ListPlugins.as_ref(), JsValue::NULL).await {
                         Ok(results) => match serde_wasm_bindgen::from_value(results) {
                             Ok(plugins) => Msg::SetPlugins(plugins),
-                            Err(e) => Msg::SetError(format!("Error fetching plugins: {:?}", e)),
+                            Err(e) => Msg::SetError(format!("Error fetching plugins: {e:?}")),
                         },
-                        Err(e) => Msg::SetError(format!("Error fetching plugins: {:?}", e)),
+                        Err(e) => Msg::SetError(format!("Error fetching plugins: {e:?}")),
                     }
                 });
                 false

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -103,7 +103,7 @@ impl SearchPage {
 
     fn scroll_to_result(&self, idx: usize) {
         let document = gloo::utils::document();
-        if let Some(el) = document.get_element_by_id(&format!("result-{}", idx)) {
+        if let Some(el) = document.get_element_by_id(&format!("result-{idx}")) {
             if let Ok(el) = el.dyn_into::<HtmlElement>() {
                 el.scroll_into_view();
             }
@@ -349,7 +349,7 @@ impl Component for SearchPage {
                         Ok(results) => Msg::UpdateLensResults(
                             serde_wasm_bindgen::from_value(results).unwrap_or_default(),
                         ),
-                        Err(e) => Msg::HandleError(format!("Error: {:?}", e)),
+                        Err(e) => Msg::HandleError(format!("Error: {e:?}")),
                     }
                 });
                 false
@@ -363,11 +363,11 @@ impl Component for SearchPage {
                         Ok(lenses) => match search_docs(lenses, query).await {
                             Ok(results) => match serde_wasm_bindgen::from_value(results) {
                                 Ok(deser) => Msg::UpdateDocsResults(deser),
-                                Err(e) => Msg::HandleError(format!("Error: {:?}", e)),
+                                Err(e) => Msg::HandleError(format!("Error: {e:?}")),
                             },
-                            Err(e) => Msg::HandleError(format!("Error: {:?}", e)),
+                            Err(e) => Msg::HandleError(format!("Error: {e:?}")),
                         },
-                        Err(e) => Msg::HandleError(format!("Error: {:?}", e)),
+                        Err(e) => Msg::HandleError(format!("Error: {e:?}")),
                     }
                 });
 
@@ -428,7 +428,7 @@ impl Component for SearchPage {
                         let open_msg = Msg::OpenResult(res.to_owned());
                         html! {
                             <SearchResultItem
-                                 id={format!("result-{}", idx)}
+                                 id={format!("result-{idx}")}
                                  onclick={link.callback(move |_| open_msg.clone())}
                                  result={res.clone()}
                                  {is_selected}
@@ -444,7 +444,7 @@ impl Component for SearchPage {
                     .map(|(idx, res)| {
                         let is_selected = idx == self.selected_idx;
                         html! {
-                            <LensResultItem id={format!("result-{}", idx)} result={res.clone()} {is_selected} />
+                            <LensResultItem id={format!("result-{idx}")} result={res.clone()} {is_selected} />
                         }
                     })
                     .collect::<Html>()

--- a/crates/client/src/pages/wizard.rs
+++ b/crates/client/src/pages/wizard.rs
@@ -50,7 +50,7 @@ pub fn wizard_page() -> Html {
                         <div>{"Star on GitHub"}</div>
                     </a>
                     <a href={constants::DISCORD_JOIN_URL} target="_blank" class="block text-center bg-neutral-900 rounded-lg p-4 hover:bg-indigo-900">
-                        <img src="discord-logo.png" class="h-8 mx-auto mb-2"/>
+                        <img src="discord-logo.png" alt="Discord Logo" class="h-8 mx-auto mb-2"/>
                         <div>{"Join our Discord"}</div>
                     </a>
                     <a href={constants::PAYMENT_URL} target="_blank" class="text-center bg-neutral-900 rounded-lg border-neutral-700 p-4 hover:bg-green-900">

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -22,6 +22,7 @@ mod m20221123_000001_add_document_tag_constraint;
 mod m20221124_000001_add_tags_for_existing_lenses;
 mod m20221210_000001_add_crawl_tags_table;
 mod m20230104_000001_add_column_n_index;
+mod m20230111_000001_add_lens_column;
 mod utils;
 
 pub struct Migrator;
@@ -49,6 +50,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221124_000001_add_tags_for_existing_lenses::Migration),
             Box::new(m20221210_000001_add_crawl_tags_table::Migration),
             Box::new(m20230104_000001_add_column_n_index::Migration),
+            Box::new(m20230111_000001_add_lens_column::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20230111_000001_add_lens_column.rs
+++ b/crates/migrations/src/m20230111_000001_add_lens_column.rs
@@ -1,0 +1,50 @@
+use entities::models::lens;
+use sea_orm_migration::prelude::*;
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20230111_000001_add_lens_column"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add remote url column, column is used to hold the url that the
+        // lens was installed from
+        if let Ok(has_col) = manager.has_column("lens", "remote_url").await {
+            if !has_col {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(lens::Entity)
+                            .add_column(ColumnDef::new(Alias::new("remote_url")).string())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        // Adds a hash column used to identify if the lens has changed or not since
+        // last load
+        if let Ok(has_col) = manager.has_column("lens", "hash").await {
+            if !has_col {
+                manager
+                    .alter_table(
+                        Table::alter()
+                            .table(lens::Entity)
+                            .add_column(ColumnDef::new(Alias::new("hash")).string())
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/shared/src/constants.rs
+++ b/crates/shared/src/constants.rs
@@ -1,3 +1,7 @@
 pub const GITHUB_REPO_URL: &str = "https://github.com/a5huynh/spyglass";
 pub const DISCORD_JOIN_URL: &str = "https://discord.gg/663wPVBSTB";
 pub const PAYMENT_URL: &str = "https://buy.stripe.com/00g0216rG5ow3MkdQQ";
+
+pub const APP_USER_AGENT: &str = "spyglass (github.com/a5huynh/spyglass)";
+pub const LENS_DIRECTORY_INDEX_URL: &str =
+    "https://raw.githubusercontent.com/spyglass-search/lens-box/main/index.ron";

--- a/crates/spyglass-rpc/src/lib.rs
+++ b/crates/spyglass-rpc/src/lib.rs
@@ -35,6 +35,9 @@ pub trait Rpc {
     #[method(name = "list_installed_lenses")]
     async fn list_installed_lenses(&self) -> Result<Vec<LensResult>, Error>;
 
+    #[method(name = "install_lens")]
+    async fn install_lens(&self, lens_name: String) -> Result<(), Error>;
+
     #[method(name = "list_plugins")]
     async fn list_plugins(&self) -> Result<Vec<PluginResult>, Error>;
 

--- a/crates/spyglass/src/crawler/cache.rs
+++ b/crates/spyglass/src/crawler/cache.rs
@@ -55,6 +55,9 @@ pub async fn update_cache(
                 store_cache(lens, resp, &cache_file, &app_state.db).await?;
                 Ok((Option::Some(cache_file), update_time))
             } else {
+                // Allow for manual processing without the need to download a cache file,
+                // can be used for archived data or testing
+                let cache_file = cache_dir.join(lens).join("parsed.manual.ron.gz");
                 if cache_file.exists() {
                     return Ok((Option::Some(cache_file), update_time));
                 }

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -219,7 +219,7 @@ async fn start_backend(state: &mut AppState, config: &Config) {
     ));
 
     // API server
-    let api_server = tokio::spawn(api::start_api_server(state.clone()));
+    let api_server = tokio::spawn(api::start_api_server(state.clone(), config.clone()));
 
     // Gracefully handle shutdowns
     match signal::ctrl_c().await {

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -423,7 +423,7 @@ pub async fn plugin_load(
             };
 
             match lens::add_or_enable(&state.db, &lens_config, lens::LensType::Plugin).await {
-                Ok(is_new) => {
+                Ok((is_new, _model)) => {
                     log::info!("loaded lens {}, new? {}", plug.name, is_new)
                 }
                 Err(e) => log::error!("Unable to add lens: {}", e),

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -437,7 +437,7 @@ pub async fn load_user_settings(
                 opts.value = value.to_string();
             }
 
-            list.push((format!("{}.{}", pname, setting_name), opts));
+            list.push((format!("{pname}.{setting_name}"), opts));
         }
     }
 

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -8,7 +8,7 @@ use tauri::api::dialog::FileDialogBuilder;
 use tauri::Manager;
 use tauri::State;
 
-use crate::plugins::lens_updater::install_lens_to_path;
+use crate::plugins::lens_updater;
 use crate::PauseState;
 use crate::{open_folder, rpc, window};
 use shared::config::{Config, Limit, UserSettings};
@@ -82,8 +82,8 @@ pub async fn open_result(_: tauri::Window, url: &str) -> Result<(), String> {
             {
                 use shared::url_to_file_path;
                 let path = url_to_file_path(url.path(), true);
-                if let Err(err) = open::that(format!("file://{}", path)) {
-                    log::error!("Unable to open file://{} due to: {}", path, err);
+                if let Err(err) = open::that(format!("file://{path}")) {
+                    log::error!("Unable to open file://{path} due to: {err}");
                 }
 
                 return Ok(());
@@ -208,20 +208,16 @@ pub async fn delete_domain<'r>(window: tauri::Window, domain: &str) -> Result<()
 #[tauri::command]
 pub async fn install_lens<'r>(
     window: tauri::Window,
-    config: State<'_, Config>,
-    download_url: &str,
+    _config: State<'_, Config>,
+    name: &str,
 ) -> Result<(), String> {
-    if let Err(e) = install_lens_to_path(download_url, config.lenses_dir()).await {
-        log::error!(
-            "Unable to install lens {}, due to error: {}",
-            download_url,
-            e
-        );
+    if let Err(e) = lens_updater::install_lens(&window.app_handle(), &name.to_string()).await {
+        log::error!("Unable to install lens {}, due to error: {}", name, e);
     } else {
         if let Some(metrics) = window.app_handle().try_state::<Metrics>() {
             metrics
                 .track(Event::InstallLens {
-                    lens: download_url.to_owned(),
+                    lens: name.to_owned(),
                 })
                 .await;
         }
@@ -398,7 +394,7 @@ pub async fn save_user_settings(
                             }
                         }
                     } else {
-                        errors.insert(key.to_string(), format!("Config not found for {}", key));
+                        errors.insert(key.to_string(), format!("Config not found for {key}"));
                     }
                 }
             }

--- a/crates/tauri/src/constants.rs
+++ b/crates/tauri/src/constants.rs
@@ -10,10 +10,6 @@ pub const VERSION_CHECK_INTERVAL_S: u64 = 60 * 60 * 6;
 // Check on start & every hour for new lenses
 pub const LENS_UPDATE_CHECK_INTERVAL_S: u64 = 60 * 60;
 
-pub const APP_USER_AGENT: &str = "spyglass (github.com/a5huynh/spyglass)";
-pub const LENS_DIRECTORY_INDEX_URL: &str =
-    "https://raw.githubusercontent.com/spyglass-search/lens-box/main/index.ron";
-
 pub const SEARCH_WIN_NAME: &str = "main";
 pub const SETTINGS_WIN_NAME: &str = "settings_window";
 pub const STARTUP_WIN_NAME: &str = "startup_window";

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -206,11 +206,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let window = window_clone.clone();
                                 window::show_search_bar(&window);
                             }) {
-                            window::alert(&window, "Error registering global shortcut", &format!("{}", e));
+                            window::alert(&window, "Error registering global shortcut", &format!("{e}"));
                         }
                     }
                 }
-                Err(e) => window::alert(&window_clone, "Error registering global shortcut", &format!("{}", e))
+                Err(e) => window::alert(&window_clone, "Error registering global shortcut", &format!("{e}"))
             }
 
             Ok(())

--- a/crates/tauri/src/plugins/lens_updater.rs
+++ b/crates/tauri/src/plugins/lens_updater.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
-use std::path::PathBuf;
 
 use tauri::{
     async_runtime::JoinHandle,
@@ -9,10 +7,8 @@ use tauri::{
 };
 use tokio::sync::broadcast;
 use tokio::time::{self, Duration};
-use url::Url;
 
 use crate::{constants, rpc, AppShutdown};
-use shared::config::Config;
 use shared::event::ClientEvent;
 use shared::response::{InstallableLens, LensResult};
 use spyglass_rpc::RpcClient;
@@ -66,8 +62,6 @@ pub fn init() -> TauriPlugin<Wry> {
 }
 
 async fn check_for_lens_updates(app_handle: &AppHandle) -> anyhow::Result<()> {
-    let config = app_handle.state::<Config>();
-
     // Get the latest lens index
     let lens_index = get_lens_index().await?;
     // Create a map from the index
@@ -92,14 +86,7 @@ async fn check_for_lens_updates(app_handle: &AppHandle) -> anyhow::Result<()> {
                     latest.download_url
                 );
 
-                // Remove old lens
-                if let Some(old_file) = lens.file_path {
-                    fs::remove_file(old_file)?;
-                }
-
-                if let Err(e) =
-                    install_lens_to_path(&latest.download_url, config.lenses_dir()).await
-                {
+                if let Err(e) = install_lens(app_handle, &latest.name).await {
                     log::error!("Unable to install lens: {}", e);
                 } else {
                     lenses_updated += 1;
@@ -115,43 +102,22 @@ async fn check_for_lens_updates(app_handle: &AppHandle) -> anyhow::Result<()> {
 
 fn http_client() -> reqwest::Client {
     reqwest::Client::builder()
-        .user_agent(constants::APP_USER_AGENT)
+        .user_agent(shared::constants::APP_USER_AGENT)
         .build()
         .expect("Unable to create reqwest client")
-}
-
-pub async fn install_lens_to_path(download_url: &str, lens_folder: PathBuf) -> anyhow::Result<()> {
-    log::info!("installing lens from <{}>", download_url);
-
-    let client = http_client();
-    let resp = client.get(download_url).send().await?;
-    let file_contents = resp.text().await?;
-
-    // Grab the file name from the end of the URL
-    let url = Url::parse(download_url)?;
-    let file_name = url
-        .path_segments()
-        .map(|c| c.collect::<Vec<_>>())
-        .and_then(|mut segs| segs.pop())
-        .expect("Unable to determine filename from lens path");
-
-    // Write file out to lens folder
-    fs::write(lens_folder.join(file_name), file_contents)?;
-
-    Ok(())
 }
 
 async fn get_lens_index() -> anyhow::Result<Vec<InstallableLens>> {
     let client = http_client();
     let resp = client
-        .get(constants::LENS_DIRECTORY_INDEX_URL)
+        .get(shared::constants::LENS_DIRECTORY_INDEX_URL)
         .send()
         .await?;
     let file_contents = resp.text().await?;
 
     match ron::from_str::<Vec<InstallableLens>>(&file_contents) {
         Ok(json) => Ok(json),
-        Err(e) => Err(anyhow::anyhow!(format!("Unable to parse index: {}", e))),
+        Err(e) => Err(anyhow::anyhow!(format!("Unable to parse index: {e}"))),
     }
 }
 
@@ -166,6 +132,24 @@ async fn get_installed_lenses(app_handle: &AppHandle) -> anyhow::Result<Vec<Lens
         Err(err) => {
             log::error!("Unable to list installed lenses: {}", err.to_string());
             Ok(Vec::new())
+        }
+    }
+}
+
+/// Helper to install the lens with the specified name. A request to the server
+/// will be made to install the lens.
+pub async fn install_lens(app_handle: &AppHandle, lens_name: &String) -> anyhow::Result<()> {
+    log::debug!("Lens install requested {}", lens_name);
+    let mutex = app_handle
+        .try_state::<rpc::RpcMutex>()
+        .ok_or_else(|| anyhow::anyhow!("Unable to get RpcMutex"))?;
+
+    let rpc = mutex.lock().await;
+    match rpc.client.install_lens(lens_name.clone()).await {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            log::error!("Unable to install lens: {} {}", lens_name, err.to_string());
+            Ok(())
         }
     }
 }

--- a/plugins/chrome-importer/src/main.rs
+++ b/plugins/chrome-importer/src/main.rs
@@ -102,7 +102,7 @@ impl SpyglassPlugin for Plugin {
         match fs::read_to_string(path.clone()) {
             Ok(blob) => match self.parse_and_queue_bookmarks(&blob) {
                 Ok(to_add) => enqueue_all(&to_add),
-                Err(e) => log(format!("Unable to parse bookmark file: {}", e)),
+                Err(e) => log(format!("Unable to parse bookmark file: {e}")),
             },
             Err(e) => log(format!("Unable to read {}: {}", path.display(), e)),
         }

--- a/plugins/firefox-importer/src/main.rs
+++ b/plugins/firefox-importer/src/main.rs
@@ -28,7 +28,7 @@ register_plugin!(Plugin);
 fn join_path(folder: &str, file: &str) -> PathBuf {
     let host_os_res = std::env::var(consts::env::HOST_OS);
     match host_os_res.unwrap_or_default().as_str() {
-        "windows" => Path::new(&format!("{}\\\\{}", folder, file)).to_path_buf(),
+        "windows" => Path::new(&format!("{folder}\\\\{file}")).to_path_buf(),
         _ => Path::new(&folder).join(file),
     }
 }

--- a/plugins/local-file-indexer/src/main.rs
+++ b/plugins/local-file-indexer/src/main.rs
@@ -63,7 +63,7 @@ impl SpyglassPlugin for Plugin {
             let diff = now - *last_processed_time;
             if diff.num_days() > 1 {
                 if let Err(e) = walk_and_enqueue_dir(path.to_path_buf(), &self.extensions) {
-                    log(format!("Unable to process dir: {}", e));
+                    log(format!("Unable to process dir: {e}"));
                 } else {
                     *last_processed_time = now;
                 }


### PR DESCRIPTION
- Client lens updater modified to send lens install request to the server
- Lens table updated to include a remote url column and hash column
- Lens is now checked on the server side to detect changes before bootstrapping