### PR TITLE
tweak: fixing slow search times due to `get_library_stats`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,27 +3018,26 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd0d559d5e679b1ab2f869b486a11182923863b1b3ee8b421763cdd707b783a"
+checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
- "jsonrpsee-http-server",
  "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
  "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
- "jsonrpsee-ws-server",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8752740ecd374bcbf8b69f3e80b0327942df76f793f8d4e60d3355650c31fb74"
+checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
  "anyhow",
  "futures-channel",
@@ -3061,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dc3e9cf2ba50b7b1d7d76a667619f82846caa39e8e8daa8a4962d74acaddca"
+checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
@@ -3074,10 +3073,8 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "globset",
- "http",
  "hyper",
  "jsonrpsee-types",
- "lazy_static",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -3087,16 +3084,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-futures",
- "unicase",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f7c0e2333ab2115c302eeb4f137c8a4af5ab609762df68bbda8f06496677c9"
+checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
 dependencies = [
  "async-trait",
  "hyper",
@@ -3109,33 +3104,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-server"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03802f0373a38c2420c70b5144742d800b509e2937edc4afb116434f07120117"
-dependencies = [
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd67957d4280217247588ac86614ead007b301ca2fa9f19c19f880a536f029e3"
+checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
 dependencies = [
+ "heck 0.4.0",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -3143,10 +3120,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.15.1"
+name = "jsonrpsee-server"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e290bba767401b646812f608c099b922d8142603c9e73a50fb192d3ac86f4a0d"
+checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
 dependencies = [
  "anyhow",
  "beef",
@@ -3158,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597b4eb94730e7695d0a2a429bc37a12e6e84d12680fdafb9b8f5f53652aab57"
+checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
 dependencies = [
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
@@ -3169,34 +3168,14 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.15.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee5feddd5188e62ac08fcf0e56478138e581509d4730f3f7be9b57dd402a4ff"
+checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-ws-server"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d488ba74fb369e5ab68926feb75a483458b88e768d44319f37e4ecad283c7325"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -5894,6 +5873,7 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "futures",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -7112,6 +7092,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7160,16 +7157,6 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -25,7 +25,7 @@ extern "C" {
     fn clear_timeout(handle: i32);
 }
 
-const QUERY_DEBOUNCE_MS: u32 = 196;
+const QUERY_DEBOUNCE_MS: u32 = 256;
 
 #[derive(Clone, PartialEq, Eq)]
 pub enum ResultDisplay {

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -210,7 +210,7 @@ impl Component for SearchPage {
             blur_timeout: None,
             library_stats: None,
             library_update_interval: Some(interval),
-            is_searching: false
+            is_searching: false,
         }
     }
 

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -1,7 +1,6 @@
+use gloo::events::EventListener;
 use gloo::timers::callback::Timeout;
-use gloo::{events::EventListener, timers::callback::Interval};
 use num_format::{Buffer, Locale};
-use std::collections::HashMap;
 use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::spawn_local;
 use web_sys::{window, HtmlElement, HtmlInputElement};
@@ -9,7 +8,7 @@ use yew::{html::Scope, prelude::*};
 
 use shared::{
     event::{ClientEvent, ClientInvoke},
-    response::{self, LibraryStats, SearchMeta, SearchResult, SearchResults},
+    response::{self, SearchMeta, SearchResult, SearchResults},
 };
 
 use crate::components::{
@@ -17,7 +16,7 @@ use crate::components::{
     result::{LensResultItem, SearchResultItem},
     SelectedLens,
 };
-use crate::{invoke, listen, open, resize_window, search_docs, search_lenses, tauri_invoke};
+use crate::{invoke, listen, open, resize_window, search_docs, search_lenses};
 
 #[wasm_bindgen]
 extern "C" {
@@ -49,8 +48,6 @@ pub enum Msg {
     UpdateLensResults(Vec<response::LensResult>),
     UpdateQuery(String),
     UpdateDocsResults(SearchResults),
-    SetLibraryStats(HashMap<String, LibraryStats>),
-    UpdateLibraryStats,
 }
 pub struct SearchPage {
     lens: Vec<String>,
@@ -64,8 +61,6 @@ pub struct SearchPage {
     query: String,
     query_debounce: Option<i32>,
     blur_timeout: Option<i32>,
-    library_stats: Option<HashMap<String, LibraryStats>>,
-    library_update_interval: Option<Interval>,
     is_searching: bool,
 }
 
@@ -132,7 +127,6 @@ impl Component for SearchPage {
 
     fn create(ctx: &Context<Self>) -> Self {
         let link = ctx.link();
-        link.send_message(Msg::UpdateLibraryStats);
 
         // Listen to onblur events so we can hide the search bar
         if let Some(wind) = window() {
@@ -191,11 +185,6 @@ impl Component for SearchPage {
             });
         }
 
-        let interval = {
-            let link = link.clone();
-            Interval::new(10_000, move || link.send_message(Msg::UpdateLibraryStats))
-        };
-
         Self {
             lens: Vec::new(),
             docs_results: Vec::new(),
@@ -208,15 +197,7 @@ impl Component for SearchPage {
             query: String::new(),
             query_debounce: None,
             blur_timeout: None,
-            library_stats: None,
-            library_update_interval: Some(interval),
             is_searching: false,
-        }
-    }
-
-    fn destroy(&mut self, _ctx: &Context<Self>) {
-        if let Some(handle) = self.library_update_interval.take() {
-            handle.cancel();
         }
     }
 
@@ -449,25 +430,6 @@ impl Component for SearchPage {
 
                 false
             }
-            Msg::SetLibraryStats(stats) => {
-                self.library_stats = Some(stats);
-                true
-            }
-            Msg::UpdateLibraryStats => {
-                link.send_future_batch(async move {
-                    if let Ok(res) = tauri_invoke::<_, HashMap<String, LibraryStats>>(
-                        ClientInvoke::GetLibraryStats,
-                        "",
-                    )
-                    .await
-                    {
-                        vec![Msg::SetLibraryStats(res)]
-                    } else {
-                        Vec::new()
-                    }
-                });
-                false
-            }
         }
     }
 
@@ -545,53 +507,20 @@ impl Component for SearchPage {
                 </>
             }
         } else {
-            let mut total_docs = html! {};
-            let mut crawling_progress = html! {};
-
-            if let Some(stats_map) = &self.library_stats {
-                let mut num_docs = 0;
-                let mut is_crawling = false;
-                for (_, stats) in stats_map.iter() {
-                    num_docs += stats.total_docs();
-                    if stats.enqueued > 0 {
-                        is_crawling = true;
-                    }
+            let is_searching_indicator = if self.is_searching {
+                html! {
+                    <div class="flex flex-row gap-1 items-center">
+                        <icons::RefreshIcon width="w-3" height="h-3" animate_spin={true} />
+                        {"Searching..."}
+                    </div>
                 }
-
-                let mut num_docs_formatted = Buffer::default();
-                num_docs_formatted.write_formatted(&num_docs, &Locale::en);
-
-                if self.is_searching {
-                    total_docs = html! {
-                        <div class="flex flex-row gap-1 items-center">
-                            <icons::RefreshIcon width="w-3" height="h-3" animate_spin={true} />
-                            {"Searching..."}
-                        </div>
-                    };
-                } else {
-                    total_docs = html! {
-                        <div>
-                            {"Searching "}
-                            <span class="text-cyan-600">{num_docs_formatted}</span>
-                            {" documents."}
-                        </div>
-                    };
-
-                    if is_crawling {
-                        crawling_progress = html! {
-                            <div class="flex flex-row gap-1 items-center">
-                                <icons::RefreshIcon width="w-3" height="h-3" animate_spin={true} />
-                                {"Crawling..."}
-                            </div>
-                        };
-                    }
-                }
-            }
+            } else {
+                html! {}
+            };
 
             html! {
                 <>
-                    {total_docs}
-                    {crawling_progress}
+                    {is_searching_indicator}
                     <div class="ml-auto flex flex-row items-center align-middle">
                     {"Use"}
                     <div class="mx-1 rounded border border-neutral-500 bg-neutral-400 px-1 text-black text-[8px]">

--- a/crates/entities/src/lib.rs
+++ b/crates/entities/src/lib.rs
@@ -25,7 +25,7 @@ pub async fn get_library_stats(
             LEFT JOIN crawl_tag on crawl_queue.id = crawl_tag.crawl_queue_id
             LEFT JOIN tags on tags.id = crawl_tag.tag_id
             WHERE tags.label = "lens"
-            GROUP BY tags.value, status
+            GROUP BY lower(tags.value), lower(status)
             UNION
             SELECT
                 count(*) as "count", tags.value as "name", "Indexed" as status
@@ -33,7 +33,7 @@ pub async fn get_library_stats(
             LEFT JOIN document_tag on indexed_document.id = document_tag.indexed_document_id
             LEFT JOIN tags on tags.id = document_tag.tag_id
             WHERE tags.label = "lens"
-            group by tags.value, status;
+            group by lower(tags.value), lower(status);
         "#
         .to_string(),
     ))

--- a/crates/spyglass-rpc/Cargo.toml
+++ b/crates/spyglass-rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # We only need the macros functionality for the shared library
-jsonrpsee = { version = "0.15", features = ["macros"] }
+jsonrpsee = { version = "0.16.2", features = ["full"] }
 shared = { path = "../shared" }
 
 [lib]

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -25,7 +25,7 @@ hostname = "^0.3"
 html5ever = "0.25"
 http = "0.2"
 ignore = "0.4"
-jsonrpsee = { version = "0.15", features = ["http-server"] }
+jsonrpsee = { version = "0.16.2", features = ["server"] }
 log = "0.4"
 migration = { path = "../migrations" }
 notify = "5.0.0-pre.16"

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -137,7 +137,7 @@ pub async fn start_api_server(
     let server = HttpServerBuilder::default().build(server_addr).await?;
 
     let rpc_module = SpyglassRpc {
-        state: state.clone(),
+        state,
         config: config.clone(),
     };
     let addr = server.local_addr()?;

--- a/crates/spyglass/src/api/mod.rs
+++ b/crates/spyglass/src/api/mod.rs
@@ -7,7 +7,7 @@ use libspyglass::task::{CollectTask, ManagerCommand};
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle};
+use jsonrpsee::server::{ServerBuilder, ServerHandle};
 
 use shared::config::Config;
 use shared::request::{SearchLensesParam, SearchParam};
@@ -132,9 +132,9 @@ impl RpcServer for SpyglassRpc {
 pub async fn start_api_server(
     state: AppState,
     config: Config,
-) -> anyhow::Result<(SocketAddr, HttpServerHandle)> {
+) -> anyhow::Result<(SocketAddr, ServerHandle)> {
     let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), state.user_settings.port);
-    let server = HttpServerBuilder::default().build(server_addr).await?;
+    let server = ServerBuilder::default().build(server_addr).await?;
 
     let rpc_module = SpyglassRpc {
         state,

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -83,15 +83,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     LogTracer::init()?;
 
     log::info!("Loading prefs from: {:?}", Config::prefs_dir());
+    let num_cores = usize::from(std::thread::available_parallelism().expect("Unable to get number of cores"));
     let indexer_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("spyglass-backend")
+        .worker_threads(num_cores / 2)
         .build()
         .expect("Unable to create tokio runtime");
 
     let api_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("spyglass-api")
+        .worker_threads(num_cores / 2)
         .build()
         .expect("Unable to create tokio runtime");
 

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -83,16 +83,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     LogTracer::init()?;
 
     log::info!("Loading prefs from: {:?}", Config::prefs_dir());
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    let indexer_rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_name("spyglass-backend")
+        .build()
+        .expect("Unable to create tokio runtime");
+
+    let api_rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("spyglass-api")
         .build()
         .expect("Unable to create tokio runtime");
 
     // Run any migrations, only on headless mode.
     #[cfg(debug_assertions)]
     {
-        let migration_status = rt.block_on(async {
+        let migration_status = indexer_rt.block_on(async {
             match Migrator::run_migrations().await {
                 Ok(_) => Ok(()),
                 Err(e) => {
@@ -116,15 +122,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Initialize/Load user preferences
-    let mut state = rt.block_on(AppState::new(&config));
+    let state = indexer_rt.block_on(AppState::new(&config));
     if !args.check {
-        rt.block_on(start_backend(&mut state, &config));
+        let indexer_handle = indexer_rt.spawn(start_backend(state.clone(), config.clone()));
+        // API server
+        let api_handle = api_rt.spawn(api::start_api_server(state, config));
+
+        api_rt.block_on(async move {
+            let _ = tokio::join!(indexer_handle, api_handle);
+        });
     }
 
     Ok(())
 }
 
-async fn start_backend(state: &mut AppState, config: &Config) {
+async fn start_backend(state: AppState, config: Config) {
     // Initialize crawl_queue, requeue all in-flight tasks.
     let _ = crawl_queue::reset_processing(&state.db).await;
     if let Err(e) = lens::reset(&state.db).await {
@@ -218,9 +230,6 @@ async fn start_backend(state: &mut AppState, config: &Config) {
         plugin_cmd_rx,
     ));
 
-    // API server
-    let api_server = tokio::spawn(api::start_api_server(state.clone(), config.clone()));
-
     // Gracefully handle shutdowns
     match signal::ctrl_c().await {
         Ok(()) => {
@@ -247,7 +256,6 @@ async fn start_backend(state: &mut AppState, config: &Config) {
         manager_handle,
         worker_handle,
         pm_handle,
-        api_server,
         lens_watcher_handle
     );
 }

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri-build = { version = "1.0.0", features = [] }
 [dependencies]
 anyhow = "1.0"
 auto-launch = "0.4.0"
-jsonrpsee = { version = "0.15", features = ["full"] }
+jsonrpsee = { version = "0.16.2", features = ["http-client"] }
 log = "0.4"
 migration = { path = "../migrations" }
 num-format = "0.4"


### PR DESCRIPTION
- Optimize library stats SQL and move out of searchbar until we have a faster (cached?) version.
- add a search in progress indicator
- bump jsonrpsee version