### PR TITLE
bugfix: don't use 64-bit sized ints so wasm-bindgen doesn't generate BigInt64Arrays

### DIFF
--- a/crates/entities/src/lib.rs
+++ b/crates/entities/src/lib.rs
@@ -8,7 +8,7 @@ use sea_orm::{DatabaseConnection, DbBackend, DbErr, FromQueryResult, Statement};
 use shared::response::LibraryStats;
 #[derive(Debug, FromQueryResult)]
 pub struct CountByStatus {
-    count: i64,
+    count: i32,
     name: String,
     status: String,
 }

--- a/crates/shared/src/response.rs
+++ b/crates/shared/src/response.rs
@@ -54,8 +54,8 @@ impl InstallableLens {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum InstallStatus {
     NotInstalled,
-    Finished { num_docs: u64 },
-    Installing { percent: i64, status: String },
+    Finished { num_docs: u32 },
+    Installing { percent: i32, status: String },
 }
 
 impl Default for InstallStatus {
@@ -95,8 +95,8 @@ pub struct PluginResult {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SearchMeta {
     pub query: String,
-    pub num_docs: u64,
-    pub wall_time_ms: u64,
+    pub num_docs: u32,
+    pub wall_time_ms: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -127,9 +127,9 @@ pub struct SearchLensesResp {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LibraryStats {
     pub lens_name: String,
-    pub crawled: i64,
-    pub enqueued: i64,
-    pub indexed: i64,
+    pub crawled: i32,
+    pub enqueued: i32,
+    pub indexed: i32,
 }
 
 impl LibraryStats {
@@ -142,7 +142,7 @@ impl LibraryStats {
         }
     }
 
-    pub fn total_docs(&self) -> i64 {
+    pub fn total_docs(&self) -> i32 {
         if self.enqueued == 0 {
             self.indexed
         } else {
@@ -150,7 +150,7 @@ impl LibraryStats {
         }
     }
 
-    pub fn percent_done(&self) -> i64 {
+    pub fn percent_done(&self) -> i32 {
         self.crawled * 100 / (self.crawled + self.enqueued)
     }
 

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -248,7 +248,7 @@ pub async fn list_installed_lenses(state: AppState) -> Result<Vec<LensResult>, E
                     }
                 } else if lens_stats.enqueued == 0 {
                     InstallStatus::Finished {
-                        num_docs: lens_stats.indexed as u64,
+                        num_docs: lens_stats.indexed as u32,
                     }
                 } else {
                     InstallStatus::Installing {
@@ -443,8 +443,8 @@ pub async fn search(
 
     let meta = SearchMeta {
         query: search_req.query,
-        num_docs: searcher.num_docs(),
-        wall_time_ms,
+        num_docs: searcher.num_docs() as u32,
+        wall_time_ms: wall_time_ms as u32,
     };
 
     let domains: HashSet<String> = HashSet::from_iter(results.iter().map(|r| r.domain.clone()));


### PR DESCRIPTION
- Closes #254.
- Better support for older browsers that don't support that.