### PR TITLE
tweak: macos fs update fixes

### DIFF
--- a/crates/client/public/fixtures.js
+++ b/crates/client/public/fixtures.js
@@ -28,14 +28,14 @@ export let invoke = async (func_name, params) => {
                 score: 1.0
             }, {
                 doc_id: "123",
-                domain: "example.com",
-                title: "This is an example title",
+                domain: "localhost",
+                title: "/Users/Blah/Documents/Special Information",
                 description: "",
-                crawl_uri: "https://example.com/this/is/a/path",
-                url: "https://example.com/this/is/a/path",
+                crawl_uri: "file:///Users/Blah/Documents/Special%20Information",
+                url: "file:///Users/Blah/Documents/Special%20Information",
                 tags: [
-                    ['source', 'drive.google.com'],
-                    ['Lens', 'example'],
+                    ['Lens', 'files'],
+                    ['type', 'directory'],
                 ],
                 score: 1.0
             }, {

--- a/crates/client/src/components/icons.rs
+++ b/crates/client/src/components/icons.rs
@@ -181,7 +181,7 @@ pub fn filter_icon(props: &IconProps) -> Html {
 #[function_component(FolderIcon)]
 pub fn folder_icon(props: &IconProps) -> Html {
     html! {
-        <svg class={props.class()} fill="none" viewBox="0 0 24 24" stroke-width="2">
+        <svg class={props.class()} stroke="currentColor" fill="none" viewBox="0 0 24 24" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
         </svg>
     }

--- a/crates/client/src/components/result.rs
+++ b/crates/client/src/components/result.rs
@@ -28,12 +28,16 @@ fn render_icon(result: &SearchResult) -> Html {
                 icons::connection_icon(connection, "h-8", "w-8")
             }
             "file" => {
-                if let Some((_, ext)) = result.title.rsplit_once('.') {
+                let is_directory = result.tags.iter().any(|(label, value)| {
+                    label.to_lowercase() == "type" && value.to_lowercase() == "directory"
+                });
+
+                if is_directory {
+                    html! { <icons::FolderIcon height="h-8" width="w-8" classes="bg-color-white m-auto" /> }
+                } else if let Some((_, ext)) = result.title.rsplit_once('.') {
                     html! { <icons::FileExtIcon ext={ext.to_string()} class={icon_size} /> }
                 } else {
-                    html! {
-                        <img class={icon_size} alt="File" src={format!("https://favicon.spyglass.workers.dev/{}", domain.clone())} />
-                    }
+                    html! { <icons::FileExtIcon ext={"txt"} class={icon_size} /> }
                 }
             }
             _ => {

--- a/crates/entities/src/lib.rs
+++ b/crates/entities/src/lib.rs
@@ -6,6 +6,9 @@ pub mod test;
 pub use sea_orm;
 use sea_orm::{DatabaseConnection, DbBackend, DbErr, FromQueryResult, Statement};
 use shared::response::LibraryStats;
+
+pub const BATCH_SIZE: usize = 5000;
+
 #[derive(Debug, FromQueryResult)]
 pub struct CountByStatus {
     count: i32,

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -10,6 +10,7 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::BATCH_SIZE;
 use super::crawl_tag;
 use super::indexed_document;
 use super::tag::{self, get_or_create, TagPair};
@@ -17,7 +18,6 @@ use shared::config::{LensConfig, LensRule, Limit, UserSettings};
 use shared::regex::{regex_for_domain, regex_for_prefix};
 
 const MAX_RETRIES: u8 = 5;
-const BATCH_SIZE: usize = 5_000;
 
 #[derive(Debug, Clone, PartialEq, EnumIter, DeriveActiveEnum, Serialize, Deserialize, Eq)]
 #[sea_orm(rs_type = "String", db_type = "String(None)")]

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -10,10 +10,10 @@ use sea_orm::{
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::BATCH_SIZE;
 use super::crawl_tag;
 use super::indexed_document;
 use super::tag::{self, get_or_create, TagPair};
+use crate::BATCH_SIZE;
 use shared::config::{LensConfig, LensRule, Limit, UserSettings};
 use shared::regex::{regex_for_domain, regex_for_prefix};
 

--- a/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
+++ b/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
@@ -1,5 +1,4 @@
 use entities::{
-    BATCH_SIZE,
     models::{
         document_tag, indexed_document,
         lens::{self, LensType},
@@ -9,6 +8,7 @@ use entities::{
         ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait, QueryFilter, Set,
         TransactionTrait,
     },
+    BATCH_SIZE,
 };
 use sea_orm_migration::prelude::*;
 use shared::config::{Config, LensConfig};

--- a/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
+++ b/crates/migrations/src/m20221124_000001_add_tags_for_existing_lenses.rs
@@ -1,4 +1,5 @@
 use entities::{
+    BATCH_SIZE,
     models::{
         document_tag, indexed_document,
         lens::{self, LensType},
@@ -51,7 +52,7 @@ where
         .collect::<Vec<document_tag::ActiveModel>>();
 
     // Insert connections, ignoring duplicates
-    for chunk in doc_tags.chunks(5000) {
+    for chunk in doc_tags.chunks(BATCH_SIZE) {
         document_tag::Entity::insert_many(chunk.to_vec())
             .on_conflict(
                 sea_orm::sea_query::OnConflict::columns(vec![

--- a/crates/migrations/src/m20221210_000001_add_crawl_tags_table.rs
+++ b/crates/migrations/src/m20221210_000001_add_crawl_tags_table.rs
@@ -1,4 +1,5 @@
 use entities::{
+    BATCH_SIZE,
     models::{
         crawl_queue, crawl_tag,
         lens::{self, LensType},
@@ -51,7 +52,7 @@ where
         .collect::<Vec<crawl_tag::ActiveModel>>();
 
     // Insert connections, ignoring duplicates
-    for chunk in task_tags.chunks(5000) {
+    for chunk in task_tags.chunks(BATCH_SIZE) {
         crawl_tag::Entity::insert_many(chunk.to_vec())
             .on_conflict(
                 sea_orm::sea_query::OnConflict::columns(vec![

--- a/crates/migrations/src/m20221210_000001_add_crawl_tags_table.rs
+++ b/crates/migrations/src/m20221210_000001_add_crawl_tags_table.rs
@@ -1,5 +1,4 @@
 use entities::{
-    BATCH_SIZE,
     models::{
         crawl_queue, crawl_tag,
         lens::{self, LensType},
@@ -9,6 +8,7 @@ use entities::{
         ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait, QueryFilter, Set,
         Statement, TransactionTrait,
     },
+    BATCH_SIZE,
 };
 use sea_orm_migration::prelude::*;
 use shared::config::{Config, LensConfig};

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 migration = { path = "../migrations" }
 mime = "0.3.16"
 new_mime_guess = "4.0.1"
-notify = { version = "5.0.0", default-features = false , features = ["serde", "macos_kqueue"]}
+notify = { version = "5.1.0", default-features = false, features = ["serde", "macos_fsevent"] }
 notify-debouncer-mini = { version = "*", default-features = false }
 open = "3.0"
 percent-encoding = "2.2"

--- a/crates/spyglass/src/documents/mod.rs
+++ b/crates/spyglass/src/documents/mod.rs
@@ -141,7 +141,7 @@ pub async fn process_crawl_results(
                 updates.push(indexed_document::ActiveModel {
                     domain: Set(url_host.to_string()),
                     url: Set(url.to_string()),
-                    open_url: Set(Some(url.to_string())),
+                    open_url: Set(crawl_result.open_url.clone()),
                     doc_id: Set(doc_id),
                     ..Default::default()
                 });

--- a/crates/spyglass/src/documents/mod.rs
+++ b/crates/spyglass/src/documents/mod.rs
@@ -173,8 +173,9 @@ pub async fn process_crawl_results(
     tx.commit().await?;
 
     log::debug!(
-        "Took {:?} to process crawl results",
-        now.elapsed().as_millis()
+        "Took {:?} to process crawl {} results",
+        now.elapsed().as_millis(),
+        num_entries,
     );
 
     let num_updates = existing.len();

--- a/crates/spyglass/src/filesystem/mod.rs
+++ b/crates/spyglass/src/filesystem/mod.rs
@@ -1,10 +1,10 @@
 use dashmap::DashMap;
-use entities::BATCH_SIZE;
 use entities::models::crawl_queue::{self, CrawlType, EnqueueSettings};
 use entities::models::tag::{TagPair, TagType};
 use entities::models::{lens, processed_files};
 use entities::sea_orm::entity::prelude::*;
 use entities::sea_orm::DatabaseConnection;
+use entities::BATCH_SIZE;
 use ignore::gitignore::Gitignore;
 use ignore::WalkBuilder;
 

--- a/crates/spyglass/src/filesystem/mod.rs
+++ b/crates/spyglass/src/filesystem/mod.rs
@@ -353,7 +353,7 @@ impl SpyglassFileWatcher {
     /// Checks if the path represents a hidden directory or
     /// or file ignored by a .gitignore file
     fn is_ignored(&self, path: &Path) -> bool {
-        if utils::is_in_hidden_dir(path) {
+        if utils::is_hidden(path) {
             return true;
         }
 
@@ -418,7 +418,7 @@ impl SpyglassFileWatcher {
         // will not ignore hidden since we need to include .git files
         let walker = WalkBuilder::new(path).hidden(false).build();
         for entry in walker.flatten() {
-            if !utils::is_in_hidden_dir(entry.path()) {
+            if !utils::is_hidden(entry.path()) {
                 if utils::is_ignore_file(entry.path()) {
                     self.add_ignore_file(entry.path());
                 }

--- a/crates/spyglass/src/filesystem/utils.rs
+++ b/crates/spyglass/src/filesystem/utils.rs
@@ -181,14 +181,20 @@ pub fn patterns_from_file(path: &Path) -> Result<Gitignore, Error> {
 /// In this case a "hidden" directory is any directory that starts with "." Example:
 /// .git
 /// .ssh
-pub fn is_in_hidden_dir(path: &Path) -> bool {
+pub fn is_hidden(path: &Path) -> bool {
+    if path.is_file() {
+        if let Some(name) = path.file_name().and_then(|x| x.to_str()) {
+            if name == ".DS_Store" {
+                return true;
+            }
+        }
+    }
+
     path.ancestors().any(|ancestor| {
         if ancestor.is_dir() {
-            if let Some(name) = ancestor.file_name() {
-                if let Some(name_str) = name.to_str() {
-                    if name_str.starts_with('.') {
-                        return true;
-                    }
+            if let Some(name) = ancestor.file_name().and_then(|s| s.to_str()) {
+                if name.starts_with('.') {
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
## local fs indexing fixes
- Use a folder icon for directories in search results.
- Shorten file path shown in result if too long.
- Ignore `.DS_Store` files during local file indexing
- Use `macos_fsevent` instead of `macos_kqueue` feature in notify crate

## other fixes
- Fix: Use open_url in document update