### PR TITLE
Add index to indexed document on doc id

### DIFF
--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -27,6 +27,7 @@ mod m20230112_000001_migrate_search_schema;
 mod m20230126_000001_create_file_table;
 mod m20230131_000001_add_is_syncing_to_connection_table;
 mod m20230201_000001_add_tag_index;
+mod m20230203_000001_add_indexed_document_index;
 mod utils;
 
 pub struct Migrator;
@@ -59,6 +60,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230126_000001_create_file_table::Migration),
             Box::new(m20230131_000001_add_is_syncing_to_connection_table::Migration),
             Box::new(m20230201_000001_add_tag_index::Migration),
+            Box::new(m20230203_000001_add_indexed_document_index::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20230203_000001_add_indexed_document_index.rs
+++ b/crates/migrations/src/m20230203_000001_add_indexed_document_index.rs
@@ -6,7 +6,7 @@ pub struct Migration;
 
 impl MigrationName for Migration {
     fn name(&self) -> &str {
-        "m20230201_000001_add_tag_index.rs"
+        "m20230203_000001_add_indexed_document_index.rs"
     }
 }
 
@@ -17,7 +17,7 @@ impl MigrationTrait for Migration {
             .get_connection()
             .execute(Statement::from_string(
                 manager.get_database_backend(),
-                "CREATE INDEX IF NOT EXISTS `idx-tag-value` ON `tags` (`value`);".to_string(),
+                "CREATE INDEX IF NOT EXISTS `idx-indexed_document-doc_id` ON `indexed_document` (`doc_id`);".to_string(),
             ))
             .await?;
 


### PR DESCRIPTION
Adding the doc id index on the indexed document table speeds up search speeds on larger data sets