### PR TITLE
bugfix: escape special characters in URL prefixes used in a regex

### DIFF
--- a/crates/shared/src/regex.rs
+++ b/crates/shared/src/regex.rs
@@ -17,6 +17,7 @@ pub fn regex_for_domain(domain: &str) -> String {
 }
 
 pub fn regex_for_prefix(prefix: &str) -> String {
+    let prefix = regex::escape(prefix);
     if prefix.ends_with('$') {
         return format!("^{prefix}");
     }

--- a/crates/shared/src/regex.rs
+++ b/crates/shared/src/regex.rs
@@ -17,12 +17,13 @@ pub fn regex_for_domain(domain: &str) -> String {
 }
 
 pub fn regex_for_prefix(prefix: &str) -> String {
-    let prefix = regex::escape(prefix);
     if prefix.ends_with('$') {
-        return format!("^{prefix}");
+        let escaped = regex::escape(prefix.strip_suffix('$').unwrap());
+        format!("^{escaped}$")
+    } else {
+        let escaped = regex::escape(prefix);
+        format!("^{escaped}.*")
     }
-
-    format!("^{prefix}.*")
 }
 
 /// Convert a robots.txt rule into a proper regex string
@@ -134,5 +135,10 @@ mod test {
         ] {
             assert!(!regex.is_match(test));
         }
+
+        let prefix = "https://en.wikipedia.org/wiki/\'($";
+        let regex = Regex::new(&regex_for_prefix(prefix)).unwrap();
+        dbg!(&regex);
+        assert!(regex.is_match("https://en.wikipedia.org/wiki/\'("));
     }
 }

--- a/crates/spyglass/src/api/route.rs
+++ b/crates/spyglass/src/api/route.rs
@@ -755,6 +755,8 @@ mod test {
             .await
             .expect("Unable to find indexed docs");
         assert_eq!(indexed.len(), 0);
+        // Add a small delay so that the documents can be properly committed
+        std::thread::sleep(std::time::Duration::from_millis(500));
         assert_eq!(state.index.reader.searcher().num_docs(), 0);
     }
 }

--- a/crates/tauri/src/menu.rs
+++ b/crates/tauri/src/menu.rs
@@ -1,9 +1,12 @@
+
 use shared::config::Config;
 use strum_macros::{Display, EnumString};
 use tauri::{
-    utils::assets::EmbeddedAssets, Context, CustomMenuItem, Menu, MenuItem, Submenu,
+    utils::assets::EmbeddedAssets, Context, CustomMenuItem, Menu,
     SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu,
 };
+#[cfg(not(target_os = "linux"))]
+use tauri::{MenuItem, Submenu};
 
 #[derive(Display, Debug, EnumString)]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
@@ -95,16 +98,16 @@ pub fn get_tray_menu(ctx: &Context<EmbeddedAssets>, config: &Config) -> SystemTr
         .add_item(quit)
 }
 
-pub fn get_app_menu(ctx: &Context<EmbeddedAssets>) -> Menu {
-    if cfg!(target_os = "linux") {
-        return Menu::new();
-    }
+pub fn get_app_menu(_ctx: &Context<EmbeddedAssets>) -> Menu {
+    #[cfg(target_os = "linux")]
+    return Menu::new();
 
+    #[cfg(not(target_os = "linux"))]
     Menu::new().add_submenu(Submenu::new(
-        &ctx.package_info().name,
+        &_ctx.package_info().name,
         Menu::new()
             .add_native_item(MenuItem::About(
-                ctx.package_info().name.to_string(),
+                _ctx.package_info().name.to_string(),
                 Default::default(),
             ))
             // Currently we need to include these so that the shortcuts for these


### PR DESCRIPTION
Also fixes macos shortcuts for text manip (Cmd+A, etc.)