### PR TITLE
bugfix: gracefully handle `uri_to_path` errors 

### DIFF
--- a/crates/spyglass/src/crawler/robots.rs
+++ b/crates/spyglass/src/crawler/robots.rs
@@ -113,7 +113,7 @@ pub async fn check_resource_rules(db: &DatabaseConnection, client: &HTTPClient, 
 
         let res = client.get(&robots_url).await;
         match res {
-            Err(err) => log::error!("Unable to check robots.txt {}", err.to_string()),
+            Err(err) => log::warn!("Unable to check robots.txt {}", err.to_string()),
             Ok(res) => {
                 match res.status() {
                     StatusCode::OK => {

--- a/crates/spyglass/src/filesystem/mod.rs
+++ b/crates/spyglass/src/filesystem/mod.rs
@@ -476,6 +476,8 @@ impl SpyglassFileWatcher {
                                     to_recrawl.push((item.file_path, file_last_mod));
                                 }
                                 Err(err) => {
+                                    // delete any invalid paths from db
+                                    to_delete.push(item.id);
                                     log::error!(
                                         "uri_to_path failed on {} due to {}",
                                         file_path,
@@ -494,6 +496,8 @@ impl SpyglassFileWatcher {
                             to_delete.push(item.id)
                         }
                         Err(err) => {
+                            // delete any invalid paths from db
+                            to_delete.push(item.id);
                             log::error!("uri_to_path failed on {} due to {}", item.file_path, err);
                         }
                     },

--- a/crates/spyglass/src/pipeline/mod.rs
+++ b/crates/spyglass/src/pipeline/mod.rs
@@ -61,8 +61,7 @@ pub async fn initialize_pipelines(
     // Grab all pipelines
     let configured_pipelines: HashSet<String> = lens_map
         .iter()
-        .filter(|entry| entry.value().pipeline.as_ref().is_some())
-        .map(|entry| entry.value().pipeline.as_ref().unwrap().clone())
+        .filter_map(|entry| entry.value().pipeline.clone())
         .collect();
 
     let mut pipelines: HashMap<String, PipelineConfiguration> = HashMap::new();
@@ -81,7 +80,7 @@ pub async fn initialize_pipelines(
                 app_state.clone(),
                 config.clone(),
                 pipeline.clone(),
-                pipelines.get(&pipeline).unwrap().clone(),
+                pipelines.get(&pipeline).expect("Expected pipeline").clone(),
                 pipeline_cmd_rx,
             ));
         } else {


### PR DESCRIPTION
Can cause a panic if it's unable to convert the file URI to a path