### PR TITLE
ci: build macOS universal binary + fix code signing issues on older macOS version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,60 +95,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
         TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        # required for macOS code signing
-        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        # disable code signing for now
+        ENABLE_CODE_SIGNING: ""
       with:
         # Build universal binary on macOS
         args: --target universal-apple-darwin
-        # the action automatically replaces \_\_VERSION\_\_ with the app version
-        tagName: test__VERSION__
-        tauriScript: cargo tauri
-        releaseName: "universal macOS binary"
-        releaseBody: "See the assets to download this version and install."
-        releaseDraft: true
-        prerelease: false
-    - uses: tauri-apps/tauri-action@dev
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        # required for macOS code signing
-        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-      with:
-        # Build universal binary on macOS
-        args: --target x86_64-apple-darwin
-        # the action automatically replaces \_\_VERSION\_\_ with the app version
-        tagName: test__VERSION__
-        tauriScript: cargo tauri
-        releaseName: "universal macOS binary"
-        releaseBody: "See the assets to download this version and install."
-        releaseDraft: true
-        prerelease: false
-    - uses: tauri-apps/tauri-action@dev
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
-        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        # required for macOS code signing
-        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-      with:
-        # Build universal binary on macOS
-        args: --target aarch64-apple-darwin
         # the action automatically replaces \_\_VERSION\_\_ with the app version
         tagName: test__VERSION__
         tauriScript: cargo tauri

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,12 @@ on:
   push:
     branches:
       - release
-      - ci/build-macos-universal
 jobs:
   publish-tauri:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest]
-
+        platform: [macos-latest, 'ubuntu-20.04', 'windows-latest']
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
@@ -104,11 +102,11 @@ jobs:
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       with:
         # Build universal binary on macOS
-        args: --target universal-apple-darwin
+        args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
         # the action automatically replaces \_\_VERSION\_\_ with the app version
-        tagName: test__VERSION__
+        tagName: v20__VERSION__
         tauriScript: cargo tauri
-        releaseName: "universal macOS binary"
+        releaseName: "Spyglass v20__VERSION__"
         releaseBody: "See the assets to download this version and install."
         releaseDraft: true
         prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -104,11 +104,55 @@ jobs:
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       with:
         # Build universal binary on macOS
-        args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
+        args: --target universal-apple-darwin
         # the action automatically replaces \_\_VERSION\_\_ with the app version
         tagName: test__VERSION__
         tauriScript: cargo tauri
-        releaseName: "Spyglass v20__VERSION__"
+        releaseName: "universal macOS binary"
+        releaseBody: "See the assets to download this version and install."
+        releaseDraft: true
+        prerelease: false
+    - uses: tauri-apps/tauri-action@dev
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        # required for macOS code signing
+        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      with:
+        # Build universal binary on macOS
+        args: --target x86_64-apple-darwin
+        # the action automatically replaces \_\_VERSION\_\_ with the app version
+        tagName: test__VERSION__
+        tauriScript: cargo tauri
+        releaseName: "universal macOS binary"
+        releaseBody: "See the assets to download this version and install."
+        releaseDraft: true
+        prerelease: false
+    - uses: tauri-apps/tauri-action@dev
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+        TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+        # required for macOS code signing
+        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+      with:
+        # Build universal binary on macOS
+        args: --target aarch64-apple-darwin
+        # the action automatically replaces \_\_VERSION\_\_ with the app version
+        tagName: test__VERSION__
+        tauriScript: cargo tauri
+        releaseName: "universal macOS binary"
         releaseBody: "See the assets to download this version and install."
         releaseDraft: true
         prerelease: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,8 +95,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
         TAURI_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
-        # disable code signing for now
-        ENABLE_CODE_SIGNING: ""
+        # required for macOS code signing
+        ENABLE_CODE_SIGNING: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       with:
         # Build universal binary on macOS
         args: --target universal-apple-darwin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,11 +69,14 @@ jobs:
         cp target/release/spyglass${{ env.target_ext }} crates/tauri/binaries/spyglass-server-${{ env.target_arch }}${{ env.target_ext }}
     - name: build sidecar (macos)
       run: |
-        cargo build -p spyglass --verbose --release --target x86_64-apple-darwin
-        cargo build -p spyglass --verbose --release --target aarch64-apple-darwin
-        mkdir -p crates/tauri/binaries
-        cp target/x86_64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-x86_64-apple-darwin
-        cp target/aarch64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-aarch64-apple-darwin
+        cargo build -p spyglass --verbose --release --target x86_64-apple-darwin;
+        cargo build -p spyglass --verbose --release --target aarch64-apple-darwin;
+        mkdir -p crates/tauri/binaries;
+        cp target/x86_64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-x86_64-apple-darwin;
+        cp target/aarch64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-aarch64-apple-darwin;
+        lipo -create -output crates/tauri/binaries/spyglass-server-universal-apple-darwin \
+          target/x86_64-apple-darwin/release/spyglass \
+          target/aarch64-apple-darwin/release/spyglass;
     - name: build default plugins
       run: make build-plugins-release
     - name: import windows certificate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,13 @@ on:
   push:
     branches:
       - release
+      - ci/build-macos-universal
 jobs:
   publish-tauri:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, 'ubuntu-20.04', 'windows-latest']
+        platform: [macos-latest]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -27,9 +28,11 @@ jobs:
     - name: install wasm32-wasi toolchain
       run: rustup target add wasm32-wasi
     # Install macos specific targets
-    - name: install arm64 rust target (macos only)
+    - name: install intel & arm64 rust target (macos only)
       if: matrix.platform == 'macos-latest'
-      run: rustup target add aarch64-apple-darwin
+      run: |
+        rustup target add aarch64-apple-darwin
+        rustup target add x86_64-apple-darwin
     # Install tauri build deps
     - name: install tauri-cli & tauri-build
       run: cargo install tauri-cli --version "^1.1"
@@ -52,11 +55,6 @@ jobs:
       run: |
         echo "target_arch=$(rustc -Vv | grep host | awk '{print $2 " "}')" >> $GITHUB_ENV
         echo "target_ext=" >> $GITHUB_ENV
-    - name: setup arch target - macos
-      if: ${{startsWith(matrix.platform, 'macos')}}
-      run: |
-        echo "target_arch=x86_64-apple-darwin" >> $GITHUB_ENV
-        echo "target_ext=" >> $GITHUB_ENV
     - name: Setup arch target (windows only)
       if: ${{startsWith(matrix.platform, 'windows')}}
       run: |
@@ -64,10 +62,18 @@ jobs:
         echo "target_ext=.exe" >> $env:GITHUB_ENV
     # Build stuff
     - name: build sidecar (windows/linux)
+      if: ${{ matrix.platform == 'windows-latest' || startsWith(matrix.platform, 'ubuntu') }}
       run: |
         cargo build -p spyglass --verbose --release
         mkdir -p crates/tauri/binaries
         cp target/release/spyglass${{ env.target_ext }} crates/tauri/binaries/spyglass-server-${{ env.target_arch }}${{ env.target_ext }}
+    - name: build sidecar (macos)
+      run: |
+        cargo build -p spyglass --verbose --release --target x86_64-apple-darwin
+        cargo build -p spyglass --verbose --release --target aarch64-apple-darwin
+        mkdir -p crates/tauri/binaries
+        cp target/x86_64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-x86_64-apple-darwin
+        cp target/aarch64-apple-darwin/release/spyglass crates/tauri/binaries/spyglass-server-aarch64-apple-darwin
     - name: build default plugins
       run: make build-plugins-release
     - name: import windows certificate
@@ -81,7 +87,7 @@ jobs:
         certutil -decode certificate/tempCert.txt certificate/certificate.pfx
         Remove-Item -path certificate -include tempCert.txt
         Import-PfxCertificate -FilePath certificate/certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String $env:WINDOWS_CERTIFICATE_PASSWORD -Force -AsPlainText)
-    - uses: tauri-apps/tauri-action@v0
+    - uses: tauri-apps/tauri-action@dev
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAURI_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
@@ -94,8 +100,10 @@ jobs:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
       with:
+        # Build universal binary on macOS
+        args: ${{ matrix.platform == 'macos-latest' && '--target universal-apple-darwin' || '' }}
         # the action automatically replaces \_\_VERSION\_\_ with the app version
-        tagName: v20__VERSION__
+        tagName: test__VERSION__
         tauriScript: cargo tauri
         releaseName: "Spyglass v20__VERSION__"
         releaseBody: "See the assets to download this version and install."

--- a/crates/tauri/entitlements.plist
+++ b/crates/tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.automation.apple-events</key><true/>
+    <key>com.apple.security.cs.allow-jit</key><true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+    <key>com.apple.security.personal-information.addressbook</key><true/>
+    <key>com.apple.security.personal-information.calendars</key><true/>
+    <key>com.apple.security.personal-information.photos-library</key><true/>
+  </dict>
+</plist><?xml version="1.0" encoding="UTF-8"?>

--- a/crates/tauri/tauri.conf.json
+++ b/crates/tauri/tauri.conf.json
@@ -38,8 +38,8 @@
         "frameworks": [],
         "minimumSystemVersion": "",
         "exceptionDomain": "",
-        "signingIdentity": null,
-        "entitlements": null,
+        "signingIdentity": "Developer ID Application: Andrew Huynh (D436KBE6J9)",
+        "entitlements": "entitlements.plist",
         "providerShortName": "AndrewHuynh1092684215"
       },
       "windows": {


### PR DESCRIPTION
- Combines ARM & Intel mac binaries into single app
- Adds required macOS entitlements to code sign
- Closes #307 
