### PR TITLE
bugfix: filesystem watcher CPU usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.5",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +876,42 @@ checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "console-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2528,6 +2610,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "flate2",
+ "nom 7.1.3",
+ "num-traits",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,6 +2782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2798,12 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2736,6 +2843,18 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3531,6 +3650,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "md-5"
@@ -4571,6 +4696,38 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3933d3ac2717077b3d5f42b40f59edfb1fb6a8c14e1c7de0f38075c4bac8e314"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de56acd5cc9642cac2a9518d4c8c53818905398fe42d33235859e0d542a7695"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -6038,6 +6195,7 @@ dependencies = [
  "calamine",
  "chrono",
  "clap 4.1.4",
+ "console-subscriber",
  "dashmap",
  "digest 0.10.6",
  "directories",
@@ -6519,6 +6677,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-deps"
@@ -7091,7 +7255,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -7202,14 +7377,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -7267,6 +7502,16 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/entities/src/models/crawl_queue.rs
+++ b/crates/entities/src/models/crawl_queue.rs
@@ -1319,32 +1319,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dequeue_recrawl() {
-        let settings = UserSettings::default();
-        let db = setup_test_db().await;
-        let url = "file:///tmp/test.txt";
-
-        let one_day_ago = chrono::Utc::now() - chrono::Duration::days(1);
-        let model = crawl_queue::ActiveModel {
-            crawl_type: Set(CrawlType::Normal),
-            domain: Set("localhost".to_string()),
-            status: Set(crawl_queue::CrawlStatus::Completed),
-            url: Set(url.to_string()),
-            created_at: Set(one_day_ago),
-            updated_at: Set(one_day_ago),
-            ..Default::default()
-        };
-
-        if let Err(res) = model.save(&db).await {
-            dbg!(res);
-        }
-
-        let queue = crawl_queue::dequeue_recrawl(&db, &settings).await.unwrap();
-        assert!(queue.is_some());
-        assert_eq!(queue.unwrap().url, url);
-    }
-
-    #[tokio::test]
     async fn test_update_or_remove_task() {
         let db = setup_test_db().await;
 

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -10,6 +10,7 @@ bytes = "1.2.1"
 calamine = "0.19.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0.32", features = ["derive"] }
+console-subscriber = { version = "0.1.8", optional = true }
 dashmap = "5.2"
 digest = "0.10"
 directories = "4.0"
@@ -69,6 +70,9 @@ shared = { path = "../shared", features = ["metrics"] }
 spyglass-netrunner = "0.2.9"
 spyglass-plugin = { path = "../spyglass-plugin" }
 spyglass-rpc = { path = "../spyglass-rpc" }
+
+[features]
+tokio-console = ["tokio/tracing", "console-subscriber"]
 
 [lib]
 name = "libspyglass"

--- a/crates/spyglass/src/filesystem/mod.rs
+++ b/crates/spyglass/src/filesystem/mod.rs
@@ -9,6 +9,7 @@ use ignore::gitignore::Gitignore;
 use ignore::WalkBuilder;
 
 use sha2::{Digest, Sha256};
+use tokio::task::JoinHandle;
 use url::Url;
 
 use crate::crawler::CrawlResult;
@@ -46,6 +47,7 @@ pub const FILES_LENS: &str = "files";
 pub struct SpyglassFileWatcher {
     // The director watcher services
     watcher: Arc<Mutex<Debouncer<RecommendedWatcher>>>,
+    pub watcher_handle: JoinHandle<()>,
     // The map of path being watched to the list of watchers
     path_map: DashMap<PathBuf, Vec<WatchPath>>,
     // Map of .gitignore file path to the ignore file processor
@@ -152,7 +154,6 @@ async fn watch_events(
             },
             _ = shutdown_rx.recv() => {
                 log::info!("🛑 Shutting down file watch loop");
-
                 file_events.close();
                 let mut watcher = state.file_watcher.lock().await;
                 if let Some(watcher) = watcher.as_mut() {
@@ -244,17 +245,14 @@ impl SpyglassFileWatcher {
             })
             .expect("Unable to watch lens directory");
 
-        let spy_watcher = SpyglassFileWatcher {
+        SpyglassFileWatcher {
             watcher: Arc::new(Mutex::new(watcher)),
+            watcher_handle: tokio::spawn(watch_events(state.clone(), file_events)),
             path_map: DashMap::new(),
             ignore_files: DashMap::new(),
             db: state.db.clone(),
             path_initializing: Arc::new(Mutex::new(None)),
-        };
-
-        tokio::spawn(watch_events(state.clone(), file_events));
-
-        spy_watcher
+        }
     }
 
     /// Helper method used to update the database with newly arrived changes

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -1,19 +1,19 @@
 extern crate notify;
 use clap::Parser;
-use std::io;
-use tokio::signal;
-use tokio::sync::{broadcast, mpsc};
-use tracing_log::LogTracer;
-use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
-
 use entities::models::{self, crawl_queue, lens};
 use libspyglass::pipeline;
 use libspyglass::plugin;
 use libspyglass::state::AppState;
 use libspyglass::task::{self, AppPause, AppShutdown, ManagerCommand};
+use migration::DbErr;
 #[allow(unused_imports)]
 use migration::Migrator;
 use shared::config::{self, Config};
+use std::io;
+use tokio::signal;
+use tokio::sync::{broadcast, mpsc};
+use tracing_log::LogTracer;
+use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 
 mod api;
 
@@ -36,10 +36,24 @@ struct CliArgs {
     check: bool,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = Config::new();
-    let args = CliArgs::parse();
+#[cfg(feature = "tokio-console")]
+pub fn setup_logging(_config: &Config) {
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            EnvFilter::from_default_env()
+                .add_directive("tokio=TRACE".parse().expect("invalid EnvFilter"))
+                .add_directive("runtime=TRACE".parse().expect("invalid EnvFilter")),
+        )
+        .with(
+            console_subscriber::ConsoleLayer::builder()
+                .with_default_env()
+                .spawn(),
+        );
+    tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
+}
 
+#[cfg(not(feature = "tokio-console"))]
+pub fn setup_logging(config: &Config) {
     #[cfg(not(debug_assertions))]
     let _guard = if config.user_settings.disable_telemetry {
         None
@@ -78,17 +92,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(fmt::Layer::new().with_writer(io::stdout))
         .with(fmt::Layer::new().with_ansi(false).with_writer(non_blocking))
         .with(sentry_tracing::layer());
-
     tracing::subscriber::set_global_default(subscriber).expect("Unable to set a global subscriber");
-    LogTracer::init()?;
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> Result<(), ()> {
+    let mut config = Config::new();
+    let args = CliArgs::parse();
+
+    setup_logging(&config);
+    LogTracer::init().expect("Unable to initialize LogTracer");
 
     log::info!("Loading prefs from: {:?}", Config::prefs_dir());
-    let backend_rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("spyglass-backend")
-        .build()
-        .expect("Unable to create tokio runtime");
-
     // In case we need to split the runtimes for some reason:
     // let num_cores = usize::from(std::thread::available_parallelism().expect("Unable to get number of cores"));
     // let api_rt = tokio::runtime::Builder::new_multi_thread()
@@ -101,23 +116,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run any migrations, only on headless mode.
     #[cfg(debug_assertions)]
     {
-        let migration_status = backend_rt.block_on(async {
-            match Migrator::run_migrations().await {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    let msg = e.to_string();
-                    // This is ok, just the migrator being funky
-                    if !msg.contains("been applied but its file is missing") {
-                        // Ruh-oh something went wrong
-                        log::error!("Unable to migrate database - {}", e.to_string());
-                        // Exit from app
-                        return Err(());
-                    }
-
-                    Ok(())
+        let migration_status: Result<(), DbErr> = match Migrator::run_migrations().await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                let msg = e.to_string();
+                // This is ok, just the migrator being funky
+                if !msg.contains("been applied but its file is missing") {
+                    // Ruh-oh something went wrong
+                    log::error!("Unable to migrate database - {}", e.to_string());
+                    // Exit from app
+                    return Err(());
                 }
+
+                Ok(())
             }
-        });
+        };
 
         if migration_status.is_err() {
             return Ok(());
@@ -125,39 +138,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     {
-        backend_rt.block_on(async {
-            // migrate plugin settings
-            let db = models::create_connection(&config, false)
-                .await
-                .expect("Unable to connect to db");
+        // migrate plugin settings
+        let db = models::create_connection(&config, false)
+            .await
+            .expect("Unable to connect to db");
 
-            // state.user_settings
-            if let Ok(Some(model)) = lens::find_by_name(config::LEGACY_FILESYSTEM_PLUGIN, &db).await
-            {
-                let mut new_settings = config.user_settings.clone();
-                new_settings.filesystem_settings.enable_filesystem_scanning = model.is_enabled;
-                let _ = Config::save_user_settings(&new_settings);
-                if let Ok(settings) = Config::load_user_settings() {
-                    config.user_settings = settings;
-                }
-
-                if let Err(err) = lens::delete_by_id(model.id, &db).await {
-                    log::error!("Error deleting filesystem plugin lens {:?}", err);
-                }
+        // state.user_settings
+        if let Ok(Some(model)) = lens::find_by_name(config::LEGACY_FILESYSTEM_PLUGIN, &db).await {
+            let mut new_settings = config.user_settings.clone();
+            new_settings.filesystem_settings.enable_filesystem_scanning = model.is_enabled;
+            let _ = Config::save_user_settings(&new_settings);
+            if let Ok(settings) = Config::load_user_settings() {
+                config.user_settings = settings;
             }
-        });
+
+            if let Err(err) = lens::delete_by_id(model.id, &db).await {
+                log::error!("Error deleting filesystem plugin lens {:?}", err);
+            }
+        }
     }
 
     // Initialize/Load user preferences
-    let state = backend_rt.block_on(AppState::new(&config));
+    let state = AppState::new(&config).await;
     if !args.check {
-        let indexer_handle = backend_rt.spawn(start_backend(state.clone(), config.clone()));
+        let indexer_handle = start_backend(state.clone(), config.clone());
         // API server
-        let api_handle = backend_rt.spawn(api::start_api_server(state, config));
-
-        backend_rt.block_on(async move {
-            let _ = tokio::join!(indexer_handle, api_handle);
-        });
+        let api_handle = api::start_api_server(state, config);
+        let _ = tokio::join!(indexer_handle, api_handle);
     }
 
     Ok(())

--- a/crates/spyglass/src/main.rs
+++ b/crates/spyglass/src/main.rs
@@ -161,9 +161,9 @@ async fn main() -> Result<(), ()> {
     // Initialize/Load user preferences
     let state = AppState::new(&config).await;
     if !args.check {
-        let indexer_handle = start_backend(state.clone(), config.clone());
+        let indexer_handle = tokio::spawn(start_backend(state.clone(), config.clone()));
         // API server
-        let api_handle = api::start_api_server(state, config);
+        let api_handle = tokio::spawn(api::start_api_server(state, config));
         let _ = tokio::join!(indexer_handle, api_handle);
     }
 

--- a/crates/spyglass/src/plugin/mod.rs
+++ b/crates/spyglass/src/plugin/mod.rs
@@ -479,9 +479,6 @@ pub async fn plugin_load(
             log::info!("<{}> plugin found", &plug.name);
         }
     }
-
-    // Startup filesystem watcher
-    tokio::spawn(crate::filesystem::configure_watcher(state.clone()));
 }
 
 pub async fn plugin_init(

--- a/crates/spyglass/src/task.rs
+++ b/crates/spyglass/src/task.rs
@@ -304,7 +304,9 @@ pub async fn worker_task(
                                     FetchResult::NotFound => {
                                         // URL no longer exists, delete from index.
                                         log::debug!("URI not found, deleting from index");
-                                        let _ = tokio::spawn(worker::handle_deletion(state.clone(), id)).await;
+                                        if let Err(err) = worker::handle_deletion(state.clone(), id).await {
+                                            log::error!("Unable to delete {id}: {err}");
+                                        }
                                     }
                                     FetchResult::Error(err) => {
                                         log::warn!("Unable to recrawl {} - {}", id, err);

--- a/crates/spyglass/src/task/manager.rs
+++ b/crates/spyglass/src/task/manager.rs
@@ -121,48 +121,4 @@ mod test {
             }
         );
     }
-
-    #[tokio::test]
-    async fn test_check_for_jobs_recrawl() {
-        let db = setup_test_db().await;
-        let state = AppState::builder().with_db(db.clone()).build();
-
-        // Insert dummy job
-        let one_day_ago = chrono::Utc::now() - chrono::Duration::days(1);
-        let task = crawl_queue::ActiveModel {
-            url: Set("file:///tmp/test.txt".to_owned()),
-            domain: Set("localhost".to_owned()),
-            crawl_type: Set(CrawlType::Normal),
-            status: Set(CrawlStatus::Completed),
-            created_at: Set(one_day_ago),
-            updated_at: Set(one_day_ago),
-            ..Default::default()
-        };
-        let _ = task.save(&db).await.expect("Unable to save dummy task");
-
-        let two_day_ago = chrono::Utc::now() - chrono::Duration::days(2);
-        let task = crawl_queue::ActiveModel {
-            url: Set("file:///tmp/this_one.txt".to_owned()),
-            domain: Set("localhost".to_owned()),
-            crawl_type: Set(CrawlType::Normal),
-            status: Set(CrawlStatus::Completed),
-            created_at: Set(two_day_ago),
-            updated_at: Set(two_day_ago),
-            ..Default::default()
-        };
-        let mut saved = task.save(&db).await.expect("Unable to save dummy task");
-
-        let (sender, mut recv) = mpsc::channel(10);
-        let has_job = check_for_jobs(&state, &sender).await;
-        assert!(has_job);
-
-        // Should return the ID of the latest task.
-        let message = recv.recv().await.expect("no WorkerCommand in channel");
-        assert_eq!(
-            message,
-            WorkerCommand::Recrawl {
-                id: saved.id.take().unwrap_or_default()
-            }
-        );
-    }
 }

--- a/crates/spyglass/src/task/manager.rs
+++ b/crates/spyglass/src/task/manager.rs
@@ -77,24 +77,6 @@ pub async fn check_for_jobs(state: &AppState, queue: &mpsc::Sender<WorkerCommand
         _ => {}
     }
 
-    // No crawl tasks, check for recrawl tasks
-    match crawl_queue::dequeue_recrawl(&state.db, &state.user_settings).await {
-        Ok(Some(task)) => {
-            // Send to worker
-            let cmd = WorkerCommand::Recrawl { id: task.id };
-            if queue.send(cmd).await.is_err() {
-                log::error!("unable to send command to worker");
-            }
-
-            started_task = Some(true);
-        }
-        Err(err) => {
-            log::error!("Unable to dequeue_recrawl jobs: {}", err.to_string());
-            started_task = Some(false);
-        }
-        _ => {}
-    }
-
     if let Some(ret) = started_task {
         ret
     } else {


### PR DESCRIPTION
- Integrating `tokio-console` into our code to make debugging tasks a lot easier (behind a feature flag)
- Fixing some orphaned spawns
- Start & manager  FS watcher task in manager task
- Remove recrawl job check (all handled by FS watcher code now)