### PR TITLE
Bugfix Client OS

### DIFF
--- a/crates/client/src/components/user_action_list.rs
+++ b/crates/client/src/components/user_action_list.rs
@@ -2,11 +2,12 @@ use crate::components::icons::BookOpen;
 use crate::components::icons::{
     ArrowTopRightOnSquare, ClipboardDocumentIcon, DownArrowInBubble, UpArrowInBubble, WinKeyIcon,
 };
+use crate::utils;
+use shared::accelerator;
 use shared::{
-    config::{self, Accelerator, UserAction, UserActionDefinition},
+    config::{self, UserAction, UserActionDefinition},
     keyboard::ModifiersState,
 };
-use std::str::FromStr;
 use yew::function_component;
 use yew::prelude::*;
 
@@ -135,7 +136,10 @@ fn user_action(props: &UserActionProps) -> Html {
     );
     let txt = props.action.label.clone();
 
-    if let Ok(accelerator) = Accelerator::from_str(props.action.key_binding.as_str()) {
+    if let Ok(accelerator) = accelerator::parse_accelerator(
+        props.action.key_binding.as_str(),
+        utils::get_os().to_string().as_str(),
+    ) {
         let key_binding = accelerator.key.to_str();
         let click_action = props.onclick.clone();
         let action = props.action.clone();

--- a/crates/client/src/components/user_action_list.rs
+++ b/crates/client/src/components/user_action_list.rs
@@ -2,7 +2,7 @@ use crate::components::icons;
 use crate::components::icons::{
     ArrowTopRightOnSquare, BookOpen, ClipboardDocumentIcon, DownArrowInBubble, UpArrowInBubble,
 };
-use crate::utils;
+use crate::utils::{self, OsName};
 use shared::accelerator;
 use shared::{
     config::{self, UserAction, UserActionDefinition},
@@ -69,18 +69,21 @@ fn modifier_icon(props: &ModifierProps) -> Html {
     };
 
     let meta_icon = if props.modifier.super_key() {
-        #[cfg(target_os = "macos")]
-        html! {
-            <div class={component_styles.clone()}>
-              <icons::CmdIcon height="h-4" width="w-4" />
-            </div>
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        html! {
-            <div class={component_styles.clone()}>
-              <icons::WinKeyIcon height="h-4" width="w-4" />
-            </div>
+        match utils::get_os() {
+            OsName::MacOS => {
+                html! {
+                  <div class={component_styles.clone()}>
+                    <icons::CmdIcon height="h-4" width="w-4" />
+                  </div>
+                }
+            }
+            _ => {
+                html! {
+                  <div class={component_styles.clone()}>
+                    <icons::WinKeyIcon height="h-4" width="w-4" />
+                  </div>
+                }
+            }
         }
     } else {
         html! {}

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -22,7 +22,7 @@ use crate::components::{
     result::{LensResultItem, SearchResultItem},
     SelectedLens,
 };
-use crate::{invoke, listen, resize_window, search_docs, search_lenses, tauri_invoke};
+use crate::{invoke, listen, resize_window, search_docs, search_lenses, tauri_invoke, utils};
 
 #[wasm_bindgen]
 extern "C" {
@@ -552,6 +552,7 @@ impl Component for SearchPage {
                                     if let Some(action) = actions.get_triggered_action(
                                         &self.modifier,
                                         &self.pressed_key.unwrap(),
+                                        utils::get_os().to_string().as_str(),
                                         context,
                                     ) {
                                         self.handle_selected_action(&action, link);

--- a/crates/client/src/utils.rs
+++ b/crates/client/src/utils.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result};
+
 use gloo::utils::window;
 
 pub enum OsName {
@@ -13,6 +15,17 @@ pub enum RequestState {
     InProgress,
     Finished,
     Error,
+}
+
+impl Display for OsName {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            OsName::MacOS => write!(f, "mac"),
+            OsName::Windows => write!(f, "windows"),
+            OsName::Linux => write!(f, "linux"),
+            OsName::Unknown => write!(f, "Unknown"),
+        }
+    }
 }
 
 impl Default for RequestState {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -11,6 +11,17 @@ pub mod regex;
 pub mod request;
 pub mod response;
 
+#[cfg(target_os = "macos")]
+pub const OS_STR: &str = "mac";
+#[cfg(target_os = "windows")]
+pub const OS_STR: &str = "windows";
+#[cfg(target_os = "linux")]
+pub const OS_STR: &str = "linux";
+
+pub const MAC_OS: &str = "mac";
+pub const WINDOWS_OS: &str = "windows";
+pub const LINUX_OS: &str = "linux";
+
 /// A platform-agnostic way to turn a URL file path into something that can
 /// be opened & crawled.
 pub fn url_to_file_path(path: &str, is_windows: bool) -> String {


### PR DESCRIPTION
Update Client OS handling to use specialized OS utility instead of rust config flags. This change is due to the fact that the os target for the client is wasm and not a specific OS